### PR TITLE
Refactor validation api

### DIFF
--- a/benchmark/validation.benchmark.js
+++ b/benchmark/validation.benchmark.js
@@ -22,7 +22,7 @@ exports.cases = [
         age: 10
       });
 
-      user.isValid();
+      user.validate();
     }
   },
   {
@@ -33,7 +33,7 @@ exports.cases = [
         age: -1
       });
 
-      user.isValid();
+      user.validate();
     }
   }
 ];

--- a/src/attributesDecorator.js
+++ b/src/attributesDecorator.js
@@ -53,7 +53,7 @@ function attributesDecorator(declaredSchema, ErroneousPassedClass) {
       });
     });
 
-    define(WrapperClass.prototype, 'isValid', validationDescriptor);
+    define(WrapperClass.prototype, 'validate', validationDescriptor);
 
     return WrapperClass;
   };

--- a/src/propertyDescriptors.js
+++ b/src/propertyDescriptors.js
@@ -30,26 +30,19 @@ exports.attributesDescriptor = {
 };
 
 exports.validationDescriptor = {
-  value() {
+  value: function validate() {
     const validation = this[SCHEMA][VALIDATE];
     const serializedStructure = serialize(this);
 
     const errors = validation.validate(serializedStructure);
 
     if(errors) {
-      define(this, 'errors', {
-        value: errors,
-        configurable: true
-      });
-
-      return false;
+      return {
+        valid: false,
+        errors
+      };
     }
 
-    define(this, 'errors', {
-      value: undefined,
-      configurable: true
-    });
-
-    return true;
+    return { valid: true };
   }
 };

--- a/test/support/validationMatchers.js
+++ b/test/support/validationMatchers.js
@@ -1,0 +1,17 @@
+const { expect } = require('chai');
+
+exports.assertValid = function assertValid(structure) {
+  const { valid, errors } = structure.validate();
+
+  expect(valid).to.be.true;
+  expect(errors).to.be.undefined;
+};
+
+exports.assertInvalid = function assertInvalid(structure, path) {
+  const { valid, errors } = structure.validate();
+
+  expect(valid).to.be.false;
+  expect(errors).to.be.instanceOf(Array);
+  expect(errors).to.have.lengthOf(1);
+  expect(errors[0].path).to.equal(path);
+};

--- a/test/unit/validation/array.spec.js
+++ b/test/unit/validation/array.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
+const { assertValid, assertInvalid } = require('../../support/validationMatchers');
 
 describe('validation', () => {
   describe('Array', () => {
@@ -17,10 +18,7 @@ describe('validation', () => {
             books: []
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -30,10 +28,7 @@ describe('validation', () => {
             books: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
     });
@@ -53,10 +48,7 @@ describe('validation', () => {
             books: []
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -66,12 +58,7 @@ describe('validation', () => {
             books: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('books');
+          assertInvalid(user, 'books');
         });
       });
     });
@@ -92,10 +79,7 @@ describe('validation', () => {
               books: ['Poetic Edda', 'Prose Edda']
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -105,12 +89,7 @@ describe('validation', () => {
               books: ['The Lusiads', undefined]
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('books.1');
+            assertInvalid(user, 'books.1');
           });
         });
       });
@@ -130,10 +109,7 @@ describe('validation', () => {
               books: ['Poetic Edda', 'Prose Edda']
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -143,10 +119,7 @@ describe('validation', () => {
               books: ['The Lusiads', undefined]
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
       });
@@ -177,10 +150,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -193,12 +163,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('books.1.name');
+          assertInvalid(user, 'books.1.name');
         });
       });
     });
@@ -221,10 +186,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -236,12 +198,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('books');
+          assertInvalid(user, 'books');
         });
       });
     });
@@ -263,10 +220,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -280,12 +234,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('books');
+          assertInvalid(user, 'books');
         });
       });
     });
@@ -308,10 +257,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -323,12 +269,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('books');
+          assertInvalid(user, 'books');
         });
       });
 
@@ -342,12 +283,7 @@ describe('validation', () => {
             ]
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('books');
+          assertInvalid(user, 'books');
         });
       });
     });

--- a/test/unit/validation/array.spec.js
+++ b/test/unit/validation/array.spec.js
@@ -17,8 +17,10 @@ describe('validation', () => {
             books: []
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -28,8 +30,10 @@ describe('validation', () => {
             books: undefined
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
     });
@@ -49,8 +53,10 @@ describe('validation', () => {
             books: []
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -60,10 +66,12 @@ describe('validation', () => {
             books: undefined
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('books');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('books');
         });
       });
     });
@@ -84,8 +92,10 @@ describe('validation', () => {
               books: ['Poetic Edda', 'Prose Edda']
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -95,10 +105,12 @@ describe('validation', () => {
               books: ['The Lusiads', undefined]
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('books.1');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('books.1');
           });
         });
       });
@@ -118,8 +130,10 @@ describe('validation', () => {
               books: ['Poetic Edda', 'Prose Edda']
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -129,8 +143,10 @@ describe('validation', () => {
               books: ['The Lusiads', undefined]
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
       });
@@ -161,8 +177,10 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -175,10 +193,12 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('books.1.name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('books.1.name');
         });
       });
     });
@@ -201,8 +221,10 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -214,10 +236,12 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('books');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('books');
         });
       });
     });
@@ -239,8 +263,10 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -254,10 +280,12 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('books');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('books');
         });
       });
     });
@@ -280,8 +308,10 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -293,10 +323,12 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('books');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('books');
         });
       });
 
@@ -310,10 +342,12 @@ describe('validation', () => {
             ]
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('books');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('books');
         });
       });
     });

--- a/test/unit/validation/boolean.spec.js
+++ b/test/unit/validation/boolean.spec.js
@@ -16,8 +16,10 @@ describe('validation', () => {
             isAdmin: true
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -27,8 +29,10 @@ describe('validation', () => {
             isAdmin: undefined
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
     });
@@ -47,8 +51,10 @@ describe('validation', () => {
             isAdmin: true
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -58,10 +64,12 @@ describe('validation', () => {
             isAdmin: undefined
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('isAdmin');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('isAdmin');
         });
       });
     });
@@ -80,8 +88,10 @@ describe('validation', () => {
             isAdmin: true
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -91,10 +101,12 @@ describe('validation', () => {
             isAdmin: false
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('isAdmin');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('isAdmin');
         });
       });
     });

--- a/test/unit/validation/boolean.spec.js
+++ b/test/unit/validation/boolean.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
+const { assertValid, assertInvalid } = require('../../support/validationMatchers');
 
 describe('validation', () => {
   describe('Boolean', () => {
@@ -16,10 +17,7 @@ describe('validation', () => {
             isAdmin: true
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -29,10 +27,7 @@ describe('validation', () => {
             isAdmin: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
     });
@@ -51,10 +46,7 @@ describe('validation', () => {
             isAdmin: true
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -64,12 +56,7 @@ describe('validation', () => {
             isAdmin: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('isAdmin');
+          assertInvalid(user, 'isAdmin');
         });
       });
     });
@@ -88,10 +75,7 @@ describe('validation', () => {
             isAdmin: true
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -101,12 +85,7 @@ describe('validation', () => {
             isAdmin: false
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('isAdmin');
+          assertInvalid(user, 'isAdmin');
         });
       });
     });

--- a/test/unit/validation/date.spec.js
+++ b/test/unit/validation/date.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
+const { assertValid, assertInvalid } = require('../../support/validationMatchers');
 
 describe('validation', () => {
   describe('Date', () => {
@@ -16,10 +17,7 @@ describe('validation', () => {
             birth: new Date()
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -29,10 +27,7 @@ describe('validation', () => {
             birth: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
     });
@@ -51,10 +46,7 @@ describe('validation', () => {
             birth: new Date()
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -64,12 +56,7 @@ describe('validation', () => {
             birth: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('birth');
+          assertInvalid(user, 'birth');
         });
       });
     });
@@ -92,10 +79,7 @@ describe('validation', () => {
             birth: nowCopy
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -107,12 +91,7 @@ describe('validation', () => {
             birth: otherTime
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('birth');
+          assertInvalid(user, 'birth');
         });
       });
     });
@@ -136,10 +115,7 @@ describe('validation', () => {
               birth: before
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -151,12 +127,7 @@ describe('validation', () => {
               birth: after
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('birth');
+            assertInvalid(user, 'birth');
           });
         });
       });
@@ -183,10 +154,7 @@ describe('validation', () => {
               updatedAt: now
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -199,12 +167,7 @@ describe('validation', () => {
               updatedAt: now
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('createdAt');
+            assertInvalid(user, 'createdAt');
           });
         });
       });
@@ -228,10 +191,7 @@ describe('validation', () => {
             birth: after
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -243,12 +203,7 @@ describe('validation', () => {
             birth: before
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('birth');
+          assertInvalid(user, 'birth');
         });
       });
     });

--- a/test/unit/validation/date.spec.js
+++ b/test/unit/validation/date.spec.js
@@ -16,8 +16,10 @@ describe('validation', () => {
             birth: new Date()
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -27,8 +29,10 @@ describe('validation', () => {
             birth: undefined
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
     });
@@ -47,8 +51,10 @@ describe('validation', () => {
             birth: new Date()
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -58,10 +64,12 @@ describe('validation', () => {
             birth: undefined
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('birth');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('birth');
         });
       });
     });
@@ -84,8 +92,10 @@ describe('validation', () => {
             birth: nowCopy
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -97,10 +107,12 @@ describe('validation', () => {
             birth: otherTime
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('birth');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('birth');
         });
       });
     });
@@ -124,8 +136,10 @@ describe('validation', () => {
               birth: before
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -137,10 +151,12 @@ describe('validation', () => {
               birth: after
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('birth');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('birth');
           });
         });
       });
@@ -167,8 +183,10 @@ describe('validation', () => {
               updatedAt: now
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -181,10 +199,12 @@ describe('validation', () => {
               updatedAt: now
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('createdAt');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('createdAt');
           });
         });
       });
@@ -208,8 +228,10 @@ describe('validation', () => {
             birth: after
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -221,10 +243,12 @@ describe('validation', () => {
             birth: before
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('birth');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('birth');
         });
       });
     });

--- a/test/unit/validation/nestedPojo.spec.js
+++ b/test/unit/validation/nestedPojo.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
+const { assertValid, assertInvalid } = require('../../support/validationMatchers');
 
 describe('validation', () => {
   describe('Nested with POJO class', () => {
@@ -18,10 +19,7 @@ describe('validation', () => {
             lastLocation: new Location()
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -31,10 +29,7 @@ describe('validation', () => {
             lastLocation: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
     });
@@ -55,10 +50,7 @@ describe('validation', () => {
             lastLocation: new Location()
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -68,12 +60,7 @@ describe('validation', () => {
             lastLocation: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('lastLocation');
+          assertInvalid(user, 'lastLocation');
         });
       });
     });

--- a/test/unit/validation/nestedPojo.spec.js
+++ b/test/unit/validation/nestedPojo.spec.js
@@ -18,8 +18,10 @@ describe('validation', () => {
             lastLocation: new Location()
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -29,8 +31,10 @@ describe('validation', () => {
             lastLocation: undefined
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
     });
@@ -51,8 +55,10 @@ describe('validation', () => {
             lastLocation: new Location()
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -62,10 +68,12 @@ describe('validation', () => {
             lastLocation: undefined
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('lastLocation');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('lastLocation');
         });
       });
     });

--- a/test/unit/validation/nestedStructure.spec.js
+++ b/test/unit/validation/nestedStructure.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
+const { assertValid, assertInvalid } = require('../../support/validationMatchers');
 
 describe('validation', () => {
   describe('Nested with structure class', () => {
@@ -25,10 +26,7 @@ describe('validation', () => {
             lastLocation: new Location()
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -38,10 +36,7 @@ describe('validation', () => {
             lastLocation: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
     });
@@ -69,10 +64,7 @@ describe('validation', () => {
             lastLocation: new Location()
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -82,12 +74,7 @@ describe('validation', () => {
             lastLocation: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('lastLocation');
+          assertInvalid(user, 'lastLocation');
         });
       });
     });
@@ -117,10 +104,7 @@ describe('validation', () => {
             lastLocation: new Location({ x: 1, y: 2 })
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -130,12 +114,7 @@ describe('validation', () => {
             lastLocation: new Location({ x: 1, y: undefined})
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('lastLocation.y');
+          assertInvalid(user, 'lastLocation.y');
         });
       });
     });

--- a/test/unit/validation/nestedStructure.spec.js
+++ b/test/unit/validation/nestedStructure.spec.js
@@ -25,8 +25,10 @@ describe('validation', () => {
             lastLocation: new Location()
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -36,8 +38,10 @@ describe('validation', () => {
             lastLocation: undefined
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
     });
@@ -65,8 +69,10 @@ describe('validation', () => {
             lastLocation: new Location()
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -76,10 +82,12 @@ describe('validation', () => {
             lastLocation: undefined
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('lastLocation');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('lastLocation');
         });
       });
     });
@@ -109,8 +117,10 @@ describe('validation', () => {
             lastLocation: new Location({ x: 1, y: 2 })
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -120,10 +130,12 @@ describe('validation', () => {
             lastLocation: new Location({ x: 1, y: undefined})
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('lastLocation.y');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('lastLocation.y');
         });
       });
     });

--- a/test/unit/validation/number.spec.js
+++ b/test/unit/validation/number.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
+const { assertValid, assertInvalid } = require('../../support/validationMatchers');
 
 describe('validation', () => {
   describe('Number', () => {
@@ -16,10 +17,7 @@ describe('validation', () => {
             age: 42
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -29,10 +27,7 @@ describe('validation', () => {
             age: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
     });
@@ -51,10 +46,7 @@ describe('validation', () => {
             age: 42
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -64,12 +56,7 @@ describe('validation', () => {
             age: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });
@@ -89,10 +76,7 @@ describe('validation', () => {
               age: 2
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -102,12 +86,7 @@ describe('validation', () => {
               age: 1
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('age');
+            assertInvalid(user, 'age');
           });
         });
       });
@@ -130,10 +109,7 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -144,10 +120,7 @@ describe('validation', () => {
               currentAge: 3
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -158,12 +131,7 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('currentAge');
+            assertInvalid(user, 'currentAge');
           });
         });
       });
@@ -186,10 +154,7 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -200,12 +165,7 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('currentAge');
+            assertInvalid(user, 'currentAge');
           });
         });
       });
@@ -226,10 +186,7 @@ describe('validation', () => {
               age: 2
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -239,10 +196,7 @@ describe('validation', () => {
               age: 3
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -252,12 +206,7 @@ describe('validation', () => {
               age: 1
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('age');
+            assertInvalid(user, 'age');
           });
         });
       });
@@ -280,10 +229,7 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -294,10 +240,7 @@ describe('validation', () => {
               currentAge: 3
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -308,12 +251,7 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('currentAge');
+            assertInvalid(user, 'currentAge');
           });
         });
       });
@@ -333,12 +271,7 @@ describe('validation', () => {
             age: 2
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
 
@@ -348,10 +281,7 @@ describe('validation', () => {
             age: 3
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -361,12 +291,7 @@ describe('validation', () => {
             age: 1
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });
@@ -385,10 +310,7 @@ describe('validation', () => {
             age: 2
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -398,10 +320,7 @@ describe('validation', () => {
             age: 1
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -411,12 +330,7 @@ describe('validation', () => {
             age: 3
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });
@@ -435,12 +349,7 @@ describe('validation', () => {
             age: 2
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
 
@@ -450,10 +359,7 @@ describe('validation', () => {
             age: 1
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -463,12 +369,7 @@ describe('validation', () => {
             age: 3
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });
@@ -487,10 +388,7 @@ describe('validation', () => {
             age: 42
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -500,12 +398,7 @@ describe('validation', () => {
             age: 4.2
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });
@@ -524,10 +417,7 @@ describe('validation', () => {
             age: 4.20
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -537,12 +427,7 @@ describe('validation', () => {
             age: 0.042
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });
@@ -561,10 +446,7 @@ describe('validation', () => {
             age: 6
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -574,12 +456,7 @@ describe('validation', () => {
             age: 7
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });
@@ -598,10 +475,7 @@ describe('validation', () => {
             age: 1
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -611,12 +485,7 @@ describe('validation', () => {
             age: 0
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
 
@@ -626,12 +495,7 @@ describe('validation', () => {
             age: -1
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });
@@ -650,10 +514,7 @@ describe('validation', () => {
             age: -1
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -663,12 +524,7 @@ describe('validation', () => {
             age: 0
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
 
@@ -678,12 +534,7 @@ describe('validation', () => {
             age: 1
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('age');
+          assertInvalid(user, 'age');
         });
       });
     });

--- a/test/unit/validation/number.spec.js
+++ b/test/unit/validation/number.spec.js
@@ -16,8 +16,10 @@ describe('validation', () => {
             age: 42
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -27,8 +29,10 @@ describe('validation', () => {
             age: undefined
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
     });
@@ -47,8 +51,10 @@ describe('validation', () => {
             age: 42
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -58,10 +64,12 @@ describe('validation', () => {
             age: undefined
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });
@@ -81,8 +89,10 @@ describe('validation', () => {
               age: 2
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -92,10 +102,12 @@ describe('validation', () => {
               age: 1
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('age');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('age');
           });
         });
       });
@@ -118,8 +130,10 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -130,8 +144,10 @@ describe('validation', () => {
               currentAge: 3
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -142,10 +158,12 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('currentAge');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('currentAge');
           });
         });
       });
@@ -168,8 +186,10 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -180,10 +200,12 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('currentAge');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('currentAge');
           });
         });
       });
@@ -204,8 +226,10 @@ describe('validation', () => {
               age: 2
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -215,8 +239,10 @@ describe('validation', () => {
               age: 3
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -226,10 +252,12 @@ describe('validation', () => {
               age: 1
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('age');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('age');
           });
         });
       });
@@ -252,8 +280,10 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -264,8 +294,10 @@ describe('validation', () => {
               currentAge: 3
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -276,10 +308,12 @@ describe('validation', () => {
               currentAge: 2
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('currentAge');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('currentAge');
           });
         });
       });
@@ -299,10 +333,12 @@ describe('validation', () => {
             age: 2
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
 
@@ -312,8 +348,10 @@ describe('validation', () => {
             age: 3
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -323,10 +361,12 @@ describe('validation', () => {
             age: 1
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });
@@ -345,8 +385,10 @@ describe('validation', () => {
             age: 2
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -356,8 +398,10 @@ describe('validation', () => {
             age: 1
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -367,10 +411,12 @@ describe('validation', () => {
             age: 3
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });
@@ -389,10 +435,12 @@ describe('validation', () => {
             age: 2
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
 
@@ -402,8 +450,10 @@ describe('validation', () => {
             age: 1
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -413,10 +463,12 @@ describe('validation', () => {
             age: 3
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });
@@ -435,8 +487,10 @@ describe('validation', () => {
             age: 42
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -446,10 +500,12 @@ describe('validation', () => {
             age: 4.2
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });
@@ -468,8 +524,10 @@ describe('validation', () => {
             age: 4.20
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -479,10 +537,12 @@ describe('validation', () => {
             age: 0.042
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });
@@ -501,8 +561,10 @@ describe('validation', () => {
             age: 6
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -512,10 +574,12 @@ describe('validation', () => {
             age: 7
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });
@@ -534,8 +598,10 @@ describe('validation', () => {
             age: 1
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -545,10 +611,12 @@ describe('validation', () => {
             age: 0
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
 
@@ -558,10 +626,12 @@ describe('validation', () => {
             age: -1
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });
@@ -580,8 +650,10 @@ describe('validation', () => {
             age: -1
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -591,10 +663,12 @@ describe('validation', () => {
             age: 0
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
 
@@ -604,10 +678,12 @@ describe('validation', () => {
             age: 1
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('age');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('age');
         });
       });
     });

--- a/test/unit/validation/string.spec.js
+++ b/test/unit/validation/string.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
+const { assertValid, assertInvalid } = require('../../support/validationMatchers');
 
 describe('validation', () => {
   describe('String', () => {
@@ -16,10 +17,7 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -29,10 +27,7 @@ describe('validation', () => {
             name: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
     });
@@ -51,10 +46,7 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -64,12 +56,7 @@ describe('validation', () => {
             name: undefined
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -88,10 +75,7 @@ describe('validation', () => {
             name: 'Something'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -101,12 +85,7 @@ describe('validation', () => {
             name: 'Another thing'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -126,10 +105,7 @@ describe('validation', () => {
               name: 'Some name'
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -139,10 +115,7 @@ describe('validation', () => {
               name: ''
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
       });
@@ -161,10 +134,7 @@ describe('validation', () => {
               name: 'Some name'
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.true;
-            expect(errors).to.be.undefined;
+            assertValid(user);
           });
         });
 
@@ -174,12 +144,7 @@ describe('validation', () => {
               name: ''
             });
 
-            const { valid, errors } = user.validate();
-
-            expect(valid).to.be.false;
-            expect(errors).to.be.instanceOf(Array);
-            expect(errors).to.have.lengthOf(1);
-            expect(errors[0].path).to.equal('name');
+            assertInvalid(user, 'name');
           });
         });
       });
@@ -200,10 +165,7 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -213,12 +175,7 @@ describe('validation', () => {
             name: 'Hi'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -237,10 +194,7 @@ describe('validation', () => {
             name: 'Some'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -250,12 +204,7 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -274,10 +223,7 @@ describe('validation', () => {
             name: 'Some'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -287,12 +233,7 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
 
@@ -302,12 +243,7 @@ describe('validation', () => {
             name: 'Hi'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -326,10 +262,7 @@ describe('validation', () => {
             name: 'A1'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -339,12 +272,7 @@ describe('validation', () => {
             name: 'Something'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -363,10 +291,7 @@ describe('validation', () => {
             name: 'A1B2'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -376,12 +301,7 @@ describe('validation', () => {
             name: 'No alphanumeric $ string'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -400,10 +320,7 @@ describe('validation', () => {
             name: 'abc'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -413,12 +330,7 @@ describe('validation', () => {
             name: 'Abc'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -437,10 +349,7 @@ describe('validation', () => {
             name: 'ABC'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -450,12 +359,7 @@ describe('validation', () => {
             name: 'Abc'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });
@@ -474,10 +378,7 @@ describe('validation', () => {
             name: 'name@host.com'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.true;
-          expect(errors).to.be.undefined;
+          assertValid(user);
         });
       });
 
@@ -487,12 +388,7 @@ describe('validation', () => {
             name: 'Not a valid email'
           });
 
-          const { valid, errors } = user.validate();
-
-          expect(valid).to.be.false;
-          expect(errors).to.be.instanceOf(Array);
-          expect(errors).to.have.lengthOf(1);
-          expect(errors[0].path).to.equal('name');
+          assertInvalid(user, 'name');
         });
       });
     });

--- a/test/unit/validation/string.spec.js
+++ b/test/unit/validation/string.spec.js
@@ -16,8 +16,10 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -27,8 +29,10 @@ describe('validation', () => {
             name: undefined
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
     });
@@ -47,8 +51,10 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -58,10 +64,12 @@ describe('validation', () => {
             name: undefined
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -80,8 +88,10 @@ describe('validation', () => {
             name: 'Something'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -91,10 +101,12 @@ describe('validation', () => {
             name: 'Another thing'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -114,8 +126,10 @@ describe('validation', () => {
               name: 'Some name'
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -125,8 +139,10 @@ describe('validation', () => {
               name: ''
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
       });
@@ -145,8 +161,10 @@ describe('validation', () => {
               name: 'Some name'
             });
 
-            expect(user.isValid()).to.be.true;
-            expect(user.errors).to.be.undefined;
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.true;
+            expect(errors).to.be.undefined;
           });
         });
 
@@ -156,10 +174,12 @@ describe('validation', () => {
               name: ''
             });
 
-            expect(user.isValid()).to.be.false;
-            expect(user.errors).to.be.instanceOf(Array);
-            expect(user.errors).to.have.lengthOf(1);
-            expect(user.errors[0].path).to.equal('name');
+            const { valid, errors } = user.validate();
+
+            expect(valid).to.be.false;
+            expect(errors).to.be.instanceOf(Array);
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].path).to.equal('name');
           });
         });
       });
@@ -180,8 +200,10 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -191,10 +213,12 @@ describe('validation', () => {
             name: 'Hi'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -213,8 +237,10 @@ describe('validation', () => {
             name: 'Some'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -224,10 +250,12 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -246,8 +274,10 @@ describe('validation', () => {
             name: 'Some'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -257,10 +287,12 @@ describe('validation', () => {
             name: 'Some name'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
 
@@ -270,10 +302,12 @@ describe('validation', () => {
             name: 'Hi'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -292,8 +326,10 @@ describe('validation', () => {
             name: 'A1'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -303,10 +339,12 @@ describe('validation', () => {
             name: 'Something'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -325,8 +363,10 @@ describe('validation', () => {
             name: 'A1B2'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -336,10 +376,12 @@ describe('validation', () => {
             name: 'No alphanumeric $ string'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -358,8 +400,10 @@ describe('validation', () => {
             name: 'abc'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -369,10 +413,12 @@ describe('validation', () => {
             name: 'Abc'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -391,8 +437,10 @@ describe('validation', () => {
             name: 'ABC'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -402,10 +450,12 @@ describe('validation', () => {
             name: 'Abc'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });
@@ -424,8 +474,10 @@ describe('validation', () => {
             name: 'name@host.com'
           });
 
-          expect(user.isValid()).to.be.true;
-          expect(user.errors).to.be.undefined;
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.true;
+          expect(errors).to.be.undefined;
         });
       });
 
@@ -435,10 +487,12 @@ describe('validation', () => {
             name: 'Not a valid email'
           });
 
-          expect(user.isValid()).to.be.false;
-          expect(user.errors).to.be.instanceOf(Array);
-          expect(user.errors).to.have.lengthOf(1);
-          expect(user.errors[0].path).to.equal('name');
+          const { valid, errors } = user.validate();
+
+          expect(valid).to.be.false;
+          expect(errors).to.be.instanceOf(Array);
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].path).to.equal('name');
         });
       });
     });


### PR DESCRIPTION
This PR refactors the validation API:

Before:

```javascript
const user = new User();

user.isValid(); // false
user.errors; // array os errors, only filled after calling `isValid()`
```

After:

```javascript
const user = new User();

const { valid, errors }  = user.validate();
valid; // false
errors; // array of errors
```