### PR TITLE
Add toJSON() method to structures

### DIFF
--- a/src/attributesDecorator.js
+++ b/src/attributesDecorator.js
@@ -1,7 +1,11 @@
 const { normalizeSchema } = require('./schemaNormalization');
 const { getInitialValues } = require('./initialValueCreation');
 const { SCHEMA } = require('./symbols');
-const { attributesDescriptor, validationDescriptor } = require('./propertyDescriptors');
+const {
+  attributesDescriptor,
+  validationDescriptor,
+  serializationDescriptor
+} = require('./propertyDescriptors');
 
 const define = Object.defineProperty;
 
@@ -54,6 +58,8 @@ function attributesDecorator(declaredSchema, ErroneousPassedClass) {
     });
 
     define(WrapperClass.prototype, 'validate', validationDescriptor);
+
+    define(WrapperClass.prototype, 'toJSON', serializationDescriptor);
 
     return WrapperClass;
   };

--- a/src/propertyDescriptors.js
+++ b/src/propertyDescriptors.js
@@ -33,7 +33,7 @@ exports.attributesDescriptor = {
 exports.validationDescriptor = {
   value: function validate() {
     const validation = this[SCHEMA][VALIDATE];
-    const serializedStructure = serialize(this);
+    const serializedStructure = this.toJSON();
 
     const errors = validation.validate(serializedStructure);
 
@@ -45,5 +45,11 @@ exports.validationDescriptor = {
     }
 
     return { valid: true };
+  }
+};
+
+exports.serializationDescriptor = {
+  value: function toJSON() {
+    return serialize(this);
   }
 };

--- a/test/unit/serialization/array.spec.js
+++ b/test/unit/serialization/array.spec.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
-const { serialize } = require('../../../src/serialization');
 
 describe('serialization', () => {
   describe('Array', () => {
@@ -25,7 +24,7 @@ describe('serialization', () => {
           ]
         });
 
-        expect(serialize(user)).to.eql({
+        expect(user.toJSON()).to.eql({
           name: 'Something',
           books: [
             { name: 'The Hobbit' }
@@ -45,7 +44,7 @@ describe('serialization', () => {
           ]
         });
 
-        const serializedUser = serialize(user);
+        const serializedUser = user.toJSON();
 
         expect(serializedUser).to.eql({
           name: 'Some name',

--- a/test/unit/serialization/jsonStringifyCompatibility.js
+++ b/test/unit/serialization/jsonStringifyCompatibility.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai');
+const { attributes } = require('../../../src');
+
+describe('JSON.stringify compatibility', () => {
+  context('when the structure is serialized with JSON.stringify', () => {
+    it('calls .toJSON() method', () => {
+      const Location = attributes({
+        x: Number,
+        y: Number
+      })(class Location { });
+
+      const User = attributes({
+        name: String,
+        location: Location
+      })(class User { });
+
+      const user = new User({
+        name: 'Some name',
+        location: new Location({
+          x: 1,
+          y: 2
+        })
+      });
+
+      expect(JSON.parse(JSON.stringify(user))).to.eql(user.toJSON());
+    });
+  });
+});

--- a/test/unit/serialization/nestedStructure.spec.js
+++ b/test/unit/serialization/nestedStructure.spec.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
-const { serialize } = require('../../../src/serialization');
 
 describe('serialization', () => {
   describe('Nested structure', () => {
@@ -26,7 +25,7 @@ describe('serialization', () => {
           location
         });
 
-        expect(serialize(user)).to.eql({
+        expect(user.toJSON()).to.eql({
           name: 'Something',
           location: {
             longitude: 123,
@@ -42,7 +41,7 @@ describe('serialization', () => {
           name: 'Some name'
         });
 
-        const serializedUser = serialize(user);
+        const serializedUser = user.toJSON();
 
         expect(serializedUser).to.eql({
           name: 'Some name',
@@ -63,7 +62,7 @@ describe('serialization', () => {
           location
         });
 
-        const serializedUser = serialize(user);
+        const serializedUser = user.toJSON();
 
         expect(serializedUser).to.eql({
           name: 'Name',

--- a/test/unit/serialization/structure.spec.js
+++ b/test/unit/serialization/structure.spec.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai');
 const { attributes } = require('../../../src');
-const { serialize } = require('../../../src/serialization');
 
 describe('serialization', () => {
   describe('Structure', () => {
@@ -16,7 +15,7 @@ describe('serialization', () => {
           age: 42
         });
 
-        expect(serialize(user)).to.eql({
+        expect(user.toJSON()).to.eql({
           name: 'Something',
           age: 42
         });
@@ -30,7 +29,7 @@ describe('serialization', () => {
           age: undefined
         });
 
-        const serializedUser = serialize(user);
+        const serializedUser = user.toJSON();
 
         expect(serializedUser).to.eql({
           name: 'Some name',


### PR DESCRIPTION
It'll add a `toJSON()` method to structures.

Also it'll be called automatically when somebody use `JSON.stringify(structure)` ([source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior))