### PR TITLE
Move all definitions to inside beforeEach blocks

### DIFF
--- a/test/unit/creatingStructureClass.spec.js
+++ b/test/unit/creatingStructureClass.spec.js
@@ -27,17 +27,21 @@ describe('creating an structure class', () => {
 
 
   describe('using class static methods and properties', () => {
-    class RawUser {
-      static staticMethod() {
-        return 'I am on a static method';
+    var User;
+
+    beforeEach(() => {
+      class RawUser {
+        static staticMethod() {
+          return 'I am on a static method';
+        }
       }
-    }
 
-    RawUser.staticProperty = 'I am a static property';
+      RawUser.staticProperty = 'I am a static property';
 
-    const User = attributes({
-      name: String
-    })(RawUser);
+      User = attributes({
+        name: String
+      })(RawUser);
+    });
 
     it('has access to static methods and properties', () => {
       expect(User.staticMethod()).to.equal('I am on a static method');
@@ -47,9 +51,13 @@ describe('creating an structure class', () => {
 
   describe('using default values for attributes', () => {
     context('when the provided default value is a function', () => {
-      const User = attributes({
-        age: { type: Number, default: () => 18 }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: { type: Number, default: () => 18 }
+        })(class User {});
+      });
 
       it('defines the attribute with the default value executing the function', () => {
         const user = new User();
@@ -59,9 +67,13 @@ describe('creating an structure class', () => {
     });
 
     context('when the provided default value is a property', () => {
-      const User = attributes({
-        age: { type: Number, default: 18 }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: { type: Number, default: 18 }
+        })(class User {});
+      });
 
       it('defines the attribute with the default value of the property', () => {
         const user = new User();

--- a/test/unit/instanceAndUpdate.spec.js
+++ b/test/unit/instanceAndUpdate.spec.js
@@ -2,16 +2,20 @@ const { expect } = require('chai');
 const { attributes } = require('../../src');
 
 describe('instantiating an structure', () => {
-  const User = attributes({
-    name: String
-  })(class User {
-    constructor() {
-      this.userInstanceStuff = 'Stuff value';
-    }
+  var User;
 
-    userMethod() {
-      return 'I am a user';
-    }
+  beforeEach(() => {
+    User = attributes({
+      name: String
+    })(class User {
+      constructor() {
+        this.userInstanceStuff = 'Stuff value';
+      }
+
+      userMethod() {
+        return 'I am a user';
+      }
+    });
   });
 
   it('has access to instance methods', () => {
@@ -58,10 +62,14 @@ describe('instantiating an structure', () => {
 });
 
 describe('updating an instance', () => {
-  const User = attributes({
-    name: String
-  })(class User {
+  var User;
 
+  beforeEach(() => {
+    User = attributes({
+      name: String
+    })(class User {
+
+    });
   });
 
   it('updates instance attribute value when assigned a new value', () => {

--- a/test/unit/serialization/array.spec.js
+++ b/test/unit/serialization/array.spec.js
@@ -3,17 +3,22 @@ const { attributes } = require('../../../src');
 
 describe('serialization', () => {
   describe('Array', () => {
-    const Book = attributes({
-      name: String
-    })(class Book {});
+    var Book;
+    var User;
 
-    const User = attributes({
-      name: String,
-      books: {
-        type: Array,
-        itemType: Book
-      }
-    })(class User {});
+    beforeEach(() => {
+      Book = attributes({
+        name: String
+      })(class Book {});
+
+      User = attributes({
+        name: String,
+        books: {
+          type: Array,
+          itemType: Book
+        }
+      })(class User {});
+    });
 
     context('when all data is present', () => {
       it('include all data defined on schema', () => {

--- a/test/unit/serialization/nestedStructure.spec.js
+++ b/test/unit/serialization/nestedStructure.spec.js
@@ -3,15 +3,20 @@ const { attributes } = require('../../../src');
 
 describe('serialization', () => {
   describe('Nested structure', () => {
-    const Location = attributes({
-      longitude: Number,
-      latitude: Number
-    })(class Location {});
+    var Location;
+    var User;
 
-    const User = attributes({
-      name: String,
-      location: Location
-    })(class User {});
+    beforeEach(() => {
+      Location = attributes({
+        longitude: Number,
+        latitude: Number
+      })(class Location {});
+
+      User = attributes({
+        name: String,
+        location: Location
+      })(class User {});
+    });
 
     context('when all data is present', () => {
       it('include all data defined on schema', () => {

--- a/test/unit/serialization/structure.spec.js
+++ b/test/unit/serialization/structure.spec.js
@@ -3,10 +3,14 @@ const { attributes } = require('../../../src');
 
 describe('serialization', () => {
   describe('Structure', () => {
-    const User = attributes({
-      name: String,
-      age: Number
-    })(class User {});
+    var User;
+
+    beforeEach(() => {
+      User = attributes({
+        name: String,
+        age: Number
+      })(class User {});
+    });
 
     context('when all data is present', () => {
       it('include all data defined on schema', () => {

--- a/test/unit/subclassingStructureClass.spec.js
+++ b/test/unit/subclassingStructureClass.spec.js
@@ -2,29 +2,34 @@ const { expect } = require('chai');
 const { attributes } = require('../../src');
 
 describe('subclassing an structure with a POJO class', () => {
-  const User = attributes({
-    name: String
-  })(class User {
-    constructor(attrs, userValue) {
-      this.userValue = userValue;
-      this.userStuff = 'User Stuff';
-    }
+  var User;
+  var Admin;
 
-    userMethod() {
-      return 'I am a user';
-    }
+  beforeEach(() => {
+    User = attributes({
+      name: String
+    })(class User {
+      constructor(attrs, userValue) {
+        this.userValue = userValue;
+        this.userStuff = 'User Stuff';
+      }
+
+      userMethod() {
+        return 'I am a user';
+      }
+    });
+
+    Admin = class Admin extends User {
+      constructor(attrs, userValue, otherValue) {
+        super(attrs, userValue);
+        this.adminValue = otherValue;
+      }
+
+      adminMethod() {
+        return 'I am an admin';
+      }
+    };
   });
-
-  class Admin extends User {
-    constructor(attrs, userValue, otherValue) {
-      super(attrs, userValue);
-      this.adminValue = otherValue;
-    }
-
-    adminMethod() {
-      return 'I am an admin';
-    }
-  }
 
   describe('instantiating an structure subclass', () => {
     it('is instance of class and superclass', () => {
@@ -115,25 +120,29 @@ describe('subclassing an structure with a POJO class', () => {
   });
 
   describe('using subclass static methods and properties', () => {
-    class RawUser {
-      static staticMethod() {
-        return 'I am on a static method';
+    var AdminStructure;
+
+    beforeEach(() => {
+      class RawUser {
+        static staticMethod() {
+          return 'I am on a static method';
+        }
       }
-    }
 
-    RawUser.staticProperty = 'I am a static property';
+      RawUser.staticProperty = 'I am a static property';
 
-    const UserStructure = attributes({
-      name: String
-    })(RawUser);
+      const UserStructure = attributes({
+        name: String
+      })(RawUser);
 
-    class AdminStructure extends UserStructure {
-      static staticAdminMethod() {
-        return 'I am also on a static method';
-      }
-    }
+      AdminStructure = class AdminStructure extends UserStructure {
+        static staticAdminMethod() {
+          return 'I am also on a static method';
+        }
+      };
 
-    AdminStructure.staticAdminProperty = 'I am also a static property';
+      AdminStructure.staticAdminProperty = 'I am also a static property';
+    });
 
     it('has access to static methods and properties', () => {
       expect(AdminStructure.staticMethod()).to.equal('I am on a static method');
@@ -145,13 +154,18 @@ describe('subclassing an structure with a POJO class', () => {
 });
 
 describe('subclassing an structure with another structure', () => {
-  const User = attributes({
-    name: String
-  })(class User {});
+  var Admin;
+  var User;
 
-  const Admin = attributes({
-    level: Number
-  })(class Admin extends User {});
+  beforeEach(() => {
+    User = attributes({
+      name: String
+    })(class User {});
+
+    Admin = attributes({
+      level: Number
+    })(class Admin extends User {});
+  });
 
   it('uses the extended schema', () => {
     const admin = new Admin({

--- a/test/unit/typeCoercion/array.spec.js
+++ b/test/unit/typeCoercion/array.spec.js
@@ -3,12 +3,16 @@ const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
   describe('Array', () => {
-    const User = attributes({
-      books: {
-        type: Array,
-        itemType: String
-      }
-    })(class User {});
+    var User;
+
+    beforeEach(() => {
+      User = attributes({
+        books: {
+          type: Array,
+          itemType: String
+        }
+      })(class User {});
+    });
 
     it('does not coerces undefined', () => {
       const user = new User({

--- a/test/unit/typeCoercion/arraySubclass.spec.js
+++ b/test/unit/typeCoercion/arraySubclass.spec.js
@@ -3,14 +3,19 @@ const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
   describe('Array subclass', () => {
-    class Collection extends Array {}
+    var Collection;
+    var User;
 
-    const User = attributes({
-      books: {
-        type: Collection,
-        itemType: String
-      }
-    })(class User {});
+    beforeEach(() => {
+      Collection = class Collection extends Array {}
+
+      User = attributes({
+        books: {
+          type: Collection,
+          itemType: String
+        }
+      })(class User {});
+    });
 
     it('does not coerces undefined', () => {
       const user = new User({

--- a/test/unit/typeCoercion/boolean.spec.js
+++ b/test/unit/typeCoercion/boolean.spec.js
@@ -3,9 +3,13 @@ const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
   describe('Boolean', () => {
-    const User = attributes({
-      isAdmin: Boolean
-    })(class User {});
+    var User;
+
+    beforeEach(() => {
+      User = attributes({
+        isAdmin: Boolean
+      })(class User {});
+    });
 
     it('does not coerces undefined', () => {
       const user = new User({

--- a/test/unit/typeCoercion/date.spec.js
+++ b/test/unit/typeCoercion/date.spec.js
@@ -3,9 +3,13 @@ const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
   describe('Date', () => {
-    const User = attributes({
-      birth: Date
-    })(class User {});
+    var User;
+
+    beforeEach(() => {
+      User = attributes({
+        birth: Date
+      })(class User {});
+    });
 
     it('does not coerce if value is already a date', () => {
       const birth = new Date();

--- a/test/unit/typeCoercion/number.spec.js
+++ b/test/unit/typeCoercion/number.spec.js
@@ -3,9 +3,13 @@ const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
   describe('Number', () => {
-    const User = attributes({
-      age: Number
-    })(class User {});
+    var User;
+
+    beforeEach(() => {
+      User = attributes({
+        age: Number
+      })(class User {});
+    });
 
     it('does not coerce if value is already a number', () => {
       const age = new Number(42);

--- a/test/unit/typeCoercion/pojo.spec.js
+++ b/test/unit/typeCoercion/pojo.spec.js
@@ -3,16 +3,21 @@ const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
   describe('POJO class', () => {
-    class Location {
-      constructor({ x, y }) {
-        this.x = x;
-        this.y = y;
-      }
-    }
+    var User;
+    var Location;
 
-    const User = attributes({
-      location: Location
-    })(class User {});
+    beforeEach(() => {
+      Location = class Location {
+        constructor({ x, y }) {
+          this.x = x;
+          this.y = y;
+        }
+      }
+
+      User = attributes({
+        location: Location
+      })(class User {});
+    });
 
     it('does not coerce if raw value is an instance of class', () => {
       const location = new Location({ x: 1, y: 2});

--- a/test/unit/typeCoercion/string.spec.js
+++ b/test/unit/typeCoercion/string.spec.js
@@ -3,9 +3,13 @@ const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
   describe('String', () => {
-    const User = attributes({
-      name: String
-    })(class User {});
+    var User;
+
+    beforeEach(() => {
+      User = attributes({
+        name: String
+      })(class User {});
+    });
 
     it('does not coerce if value is already a string', () => {
       const name = new String('Some name');

--- a/test/unit/typeCoercion/structure.spec.js
+++ b/test/unit/typeCoercion/structure.spec.js
@@ -3,14 +3,19 @@ const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
   describe('Structure class', () => {
-    const Location = attributes({
-      x: Number,
-      y: Number
-    })(class Location {});
+    var Location;
+    var User;
 
-    const User = attributes({
-      location: Location
-    })(class User {});
+    beforeEach(() => {
+      Location = attributes({
+        x: Number,
+        y: Number
+      })(class Location {});
+
+      User = attributes({
+        location: Location
+      })(class User {});
+    });
 
     it('does not coerce if raw value is an instance of class', () => {
       const location = new Location({ x: 1, y: 2});

--- a/test/unit/typeCoercion/typeCoercion.spec.js
+++ b/test/unit/typeCoercion/typeCoercion.spec.js
@@ -2,9 +2,13 @@ const { expect } = require('chai');
 const { attributes } = require('../../../src');
 
 describe('type coercion', () => {
-  const User = attributes({
-    name: String
-  })(class User {});
+  var User;
+
+  beforeEach(() => {
+    User = attributes({
+      name: String
+    })(class User {});
+  });
 
   it('coerces when assigning value', () => {
     const user = new User();

--- a/test/unit/validation/array.spec.js
+++ b/test/unit/validation/array.spec.js
@@ -4,12 +4,16 @@ const { assertValid, assertInvalid } = require('../../support/validationMatchers
 describe('validation', () => {
   describe('Array', () => {
     describe('no validation', () => {
-      const User = attributes({
-        books: {
-          type: Array,
-          itemType: String
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          books: {
+            type: Array,
+            itemType: String
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -33,13 +37,17 @@ describe('validation', () => {
     });
 
     describe('required', () => {
-      const User = attributes({
-        books: {
-          type: Array,
-          itemType: String,
-          required: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          books: {
+            type: Array,
+            itemType: String,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -64,13 +72,17 @@ describe('validation', () => {
 
     describe('sparse array', () => {
       context('when array can not be sparse', () => {
-        const User = attributes({
-          books: {
-            type: Array,
-            itemType: String,
-            sparse: false
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            books: {
+              type: Array,
+              itemType: String,
+              sparse: false
+            }
+          })(class User {});
+        });
 
         context('when all items are defined', () => {
           it('is valid', () => {
@@ -94,13 +106,17 @@ describe('validation', () => {
       });
 
       context('when array can be sparse', () => {
-        const User = attributes({
-          books: {
-            type: Array,
-            itemType: String,
-            sparse: true
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            books: {
+              type: Array,
+              itemType: String,
+              sparse: true
+            }
+          })(class User {});
+        });
 
         context('when all items are defined', () => {
           it('is valid', () => {
@@ -125,20 +141,25 @@ describe('validation', () => {
     });
 
     describe('nested validation', () => {
-      const Book = attributes({
-        name: {
-          type: String,
-          required: true
-        }
-      })(class Book {});
+      var Book;
+      var User;
 
-      const User = attributes({
-        books: {
-          type: Array,
-          itemType: Book,
-          required: true
-        }
-      })(class User {});
+      beforeEach(() => {
+        Book = attributes({
+          name: {
+            type: String,
+            required: true
+          }
+        })(class Book {});
+
+        User = attributes({
+          books: {
+            type: Array,
+            itemType: Book,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when nested value is present', () => {
         it('is valid', () => {
@@ -168,13 +189,17 @@ describe('validation', () => {
     });
 
     describe('minLength', () => {
-      const User = attributes({
-        books: {
-          type: Array,
-          itemType: String,
-          minLength: 2
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          books: {
+            type: Array,
+            itemType: String,
+            minLength: 2
+          }
+        })(class User {});
+      });
 
       context('when array has minimum length', () => {
         it('is valid', () => {
@@ -203,13 +228,17 @@ describe('validation', () => {
     });
 
     describe('maxLength', () => {
-      const User = attributes({
-        books: {
-          type: Array,
-          itemType: String,
-          maxLength: 2
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          books: {
+            type: Array,
+            itemType: String,
+            maxLength: 2
+          }
+        })(class User {});
+      });
 
       context('when array has less than maximum length', () => {
         it('is valid', () => {
@@ -239,13 +268,17 @@ describe('validation', () => {
     });
 
     describe('exactLength', () => {
-      const User = attributes({
-        books: {
-          type: Array,
-          itemType: String,
-          exactLength: 2
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          books: {
+            type: Array,
+            itemType: String,
+            exactLength: 2
+          }
+        })(class User {});
+      });
 
       context('when array has exactly the expected length', () => {
         it('is valid', () => {

--- a/test/unit/validation/boolean.spec.js
+++ b/test/unit/validation/boolean.spec.js
@@ -4,11 +4,15 @@ const { assertValid, assertInvalid } = require('../../support/validationMatchers
 describe('validation', () => {
   describe('Boolean', () => {
     describe('no validation', () => {
-      const User = attributes({
-        isAdmin: {
-          type: Boolean
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          isAdmin: {
+            type: Boolean
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -32,12 +36,16 @@ describe('validation', () => {
     });
 
     describe('required', () => {
-      const User = attributes({
-        isAdmin: {
-          type: Boolean,
-          required: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          isAdmin: {
+            type: Boolean,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -61,12 +69,16 @@ describe('validation', () => {
     });
 
     describe('equal', () => {
-      const User = attributes({
-        isAdmin: {
-          type: Boolean,
-          equal: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          isAdmin: {
+            type: Boolean,
+            equal: true
+          }
+        })(class User {});
+      });
 
       context('when value is equal', () => {
         it('is valid', () => {

--- a/test/unit/validation/date.spec.js
+++ b/test/unit/validation/date.spec.js
@@ -4,11 +4,15 @@ const { assertValid, assertInvalid } = require('../../support/validationMatchers
 describe('validation', () => {
   describe('Date', () => {
     describe('no validation', () => {
-      const User = attributes({
-        birth: {
-          type: Date
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          birth: {
+            type: Date
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -32,12 +36,16 @@ describe('validation', () => {
     });
 
     describe('required', () => {
-      const User = attributes({
-        birth: {
-          type: Date,
-          required: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          birth: {
+            type: Date,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -61,14 +69,19 @@ describe('validation', () => {
     });
 
     describe('equal', () => {
-      const now = new Date();
+      var now;
+      var User;
 
-      const User = attributes({
-        birth: {
-          type: Date,
-          equal: now
-        }
-      })(class User {});
+      beforeEach(() => {
+        now = new Date();
+
+        User = attributes({
+          birth: {
+            type: Date,
+            equal: now
+          }
+        })(class User {});
+      });
 
       context('when value is equal', () => {
         it('is valid', () => {
@@ -97,14 +110,21 @@ describe('validation', () => {
 
     describe('max', () => {
       describe('when using a value', () => {
-        const now = new Date();
+        var User;
+        var now;
 
-        const User = attributes({
-          birth: {
-            type: Date,
-            max: now
-          }
-        })(class User {});
+        before(() => {
+          now = new Date();
+        });
+
+        beforeEach(() => {
+          User = attributes({
+            birth: {
+              type: Date,
+              max: now
+            }
+          })(class User {});
+        });
 
         context('when date is before max', () => {
           it('is valid', () => {
@@ -132,17 +152,24 @@ describe('validation', () => {
       });
 
       describe('when using a reference', () => {
-        const now = new Date();
+        var now;
+        var User;
 
-        const User = attributes({
-          createdAt: {
-            type: Date,
-            max: { attr: 'updatedAt' }
-          },
-          updatedAt: {
-            type: Date
-          }
-        })(class User {});
+        before(() => {
+          now = new Date();
+        });
+
+        beforeEach(() => {
+          User = attributes({
+            createdAt: {
+              type: Date,
+              max: { attr: 'updatedAt' }
+            },
+            updatedAt: {
+              type: Date
+            }
+          })(class User {});
+        });
 
         context('when date is before max', () => {
           it('is valid', () => {
@@ -173,14 +200,18 @@ describe('validation', () => {
     });
 
     describe('min', () => {
-      const now = new Date();
+      var User;
 
-      const User = attributes({
-        birth: {
-          type: Date,
-          min: now
-        }
-      })(class User {});
+      beforeEach(() => {
+        const now = new Date();
+
+        User = attributes({
+          birth: {
+            type: Date,
+            min: now
+          }
+        })(class User {});
+      });
 
       context('when date is after min', () => {
         it('is valid', () => {

--- a/test/unit/validation/nestedPojo.spec.js
+++ b/test/unit/validation/nestedPojo.spec.js
@@ -4,13 +4,18 @@ const { assertValid, assertInvalid } = require('../../support/validationMatchers
 describe('validation', () => {
   describe('Nested with POJO class', () => {
     describe('no validation', () => {
-      class Location {}
+      var Location;
+      var User;
 
-      const User = attributes({
-        lastLocation: {
-          type: Location
-        }
-      })(class User {});
+      beforeEach(() => {
+        Location = class Location {}
+
+        User = attributes({
+          lastLocation: {
+            type: Location
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -34,14 +39,19 @@ describe('validation', () => {
     });
 
     describe('required', () => {
-      class Location {}
+      var Location;
+      var User;
 
-      const User = attributes({
-        lastLocation: {
-          type: Location,
-          required: true
-        }
-      })(class User {});
+      beforeEach(() => {
+        Location = class Location {}
+
+        User = attributes({
+          lastLocation: {
+            type: Location,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {

--- a/test/unit/validation/nestedStructure.spec.js
+++ b/test/unit/validation/nestedStructure.spec.js
@@ -4,20 +4,25 @@ const { assertValid, assertInvalid } = require('../../support/validationMatchers
 describe('validation', () => {
   describe('Nested with structure class', () => {
     describe('no validation', () => {
-      const Location = attributes({
-        x: {
-          type: Number
-        },
-        y: {
-          type: Number
-        }
-      })(class Location {});
+      var Location;
+      var User;
 
-      const User = attributes({
-        lastLocation: {
-          type: Location
-        }
-      })(class User {});
+      beforeEach(() => {
+        Location = attributes({
+          x: {
+            type: Number
+          },
+          y: {
+            type: Number
+          }
+        })(class Location {});
+
+        User = attributes({
+          lastLocation: {
+            type: Location
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -41,21 +46,26 @@ describe('validation', () => {
     });
 
     describe('required', () => {
-      const Location = attributes({
-        x: {
-          type: Number
-        },
-        y: {
-          type: Number
-        }
-      })(class Location {});
+      var Location;
+      var User;
 
-      const User = attributes({
-        lastLocation: {
-          type: Location,
-          required: true
-        }
-      })(class User {});
+      beforeEach(() => {
+        Location = attributes({
+          x: {
+            type: Number
+          },
+          y: {
+            type: Number
+          }
+        })(class Location {});
+
+        User = attributes({
+          lastLocation: {
+            type: Location,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -79,23 +89,28 @@ describe('validation', () => {
     });
 
     describe('nested required', () => {
-      const Location = attributes({
-        x: {
-          type: Number,
-          required: true
-        },
-        y: {
-          type: Number,
-          required: true
-        }
-      })(class Location {});
+      var Location;
+      var User;
 
-      const User = attributes({
-        lastLocation: {
-          type: Location,
-          required: true
-        }
-      })(class User {});
+      beforeEach(() => {
+        Location = attributes({
+          x: {
+            type: Number,
+            required: true
+          },
+          y: {
+            type: Number,
+            required: true
+          }
+        })(class Location {});
+
+        User = attributes({
+          lastLocation: {
+            type: Location,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when nested value is present', () => {
         it('is valid', () => {

--- a/test/unit/validation/number.spec.js
+++ b/test/unit/validation/number.spec.js
@@ -4,11 +4,15 @@ const { assertValid, assertInvalid } = require('../../support/validationMatchers
 describe('validation', () => {
   describe('Number', () => {
     describe('no validation', () => {
-      const User = attributes({
-        age: {
-          type: Number
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -32,12 +36,16 @@ describe('validation', () => {
     });
 
     describe('required', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          required: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -62,12 +70,16 @@ describe('validation', () => {
 
     describe('equal', () => {
       describe('when using a value', () => {
-        const User = attributes({
-          age: {
-            type: Number,
-            equal: 2
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            age: {
+              type: Number,
+              equal: 2
+            }
+          })(class User {});
+        });
 
         context('when value is equal', () => {
           it('is valid', () => {
@@ -91,15 +103,19 @@ describe('validation', () => {
       });
 
       describe('when using a mixed array os possibilities', () => {
-        const User = attributes({
-          startAge: {
-            type: Number
-          },
-          currentAge: {
-            type: Number,
-            equal: [{ attr: 'startAge' }, 3]
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            startAge: {
+              type: Number
+            },
+            currentAge: {
+              type: Number,
+              equal: [{ attr: 'startAge' }, 3]
+            }
+          })(class User {});
+        });
 
         context('when value is equal to referenced attribute', () => {
           it('is valid', () => {
@@ -136,15 +152,19 @@ describe('validation', () => {
       });
 
       describe('when using a reference', () => {
-        const User = attributes({
-          startAge: {
-            type: Number
-          },
-          currentAge: {
-            type: Number,
-            equal: { attr: 'startAge' }
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            startAge: {
+              type: Number
+            },
+            currentAge: {
+              type: Number,
+              equal: { attr: 'startAge' }
+            }
+          })(class User {});
+        });
 
         context('when value is equal to referenced attribute', () => {
           it('is valid', () => {
@@ -172,12 +192,16 @@ describe('validation', () => {
 
     describe('min', () => {
       describe('when using a number', () => {
-        const User = attributes({
-          age: {
-            type: Number,
-            min: 2
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            age: {
+              type: Number,
+              min: 2
+            }
+          })(class User {});
+        });
 
         context('when value is equal to min', () => {
           it('is valid', () => {
@@ -211,15 +235,19 @@ describe('validation', () => {
       });
 
       describe('when using a reference to another attribute', () => {
-        const User = attributes({
-          startAge: {
-            type: Number
-          },
-          currentAge: {
-            type: Number,
-            min: { attr: 'startAge' }
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            startAge: {
+              type: Number
+            },
+            currentAge: {
+              type: Number,
+              min: { attr: 'startAge' }
+            }
+          })(class User {});
+        });
 
         context('when value is equal to referenced attribute', () => {
           it('is valid', () => {
@@ -257,12 +285,16 @@ describe('validation', () => {
     });
 
     describe('greater', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          greater: 2
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            greater: 2
+          }
+        })(class User {});
+      });
 
       context('when value is equal to greater', () => {
         it('is not valid and has errors set', () => {
@@ -296,12 +328,16 @@ describe('validation', () => {
     });
 
     describe('max', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          max: 2
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            max: 2
+          }
+        })(class User {});
+      });
 
       context('when value is equal to max', () => {
         it('is valid', () => {
@@ -335,12 +371,16 @@ describe('validation', () => {
     });
 
     describe('less', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          less: 2
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            less: 2
+          }
+        })(class User {});
+      });
 
       context('when value is equal to less', () => {
         it('is not valid and has errors set', () => {
@@ -374,12 +414,16 @@ describe('validation', () => {
     });
 
     describe('integer', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          integer: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            integer: true
+          }
+        })(class User {});
+      });
 
       context('when value is an integer', () => {
         it('is valid', () => {
@@ -403,12 +447,16 @@ describe('validation', () => {
     });
 
     describe('precision', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          precision: 2
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            precision: 2
+          }
+        })(class User {});
+      });
 
       context('when value has less than precision decimal places', () => {
         it('is valid', () => {
@@ -432,12 +480,16 @@ describe('validation', () => {
     });
 
     describe('multiple', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          multiple: 3
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            multiple: 3
+          }
+        })(class User {});
+      });
 
       context('when value is multiple of given value', () => {
         it('is valid', () => {
@@ -461,12 +513,16 @@ describe('validation', () => {
     });
 
     describe('positive', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          positive: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            positive: true
+          }
+        })(class User {});
+      });
 
       context('when value is positive', () => {
         it('is valid', () => {
@@ -500,12 +556,16 @@ describe('validation', () => {
     });
 
     describe('negative', () => {
-      const User = attributes({
-        age: {
-          type: Number,
-          negative: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          age: {
+            type: Number,
+            negative: true
+          }
+        })(class User {});
+      });
 
       context('when value is negative', () => {
         it('is valid', () => {

--- a/test/unit/validation/string.spec.js
+++ b/test/unit/validation/string.spec.js
@@ -4,11 +4,15 @@ const { assertValid, assertInvalid } = require('../../support/validationMatchers
 describe('validation', () => {
   describe('String', () => {
     describe('no validation', () => {
-      const User = attributes({
-        name: {
-          type: String
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -32,12 +36,16 @@ describe('validation', () => {
     });
 
     describe('required', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          required: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            required: true
+          }
+        })(class User {});
+      });
 
       context('when value is present', () => {
         it('is valid', () => {
@@ -61,12 +69,16 @@ describe('validation', () => {
     });
 
     describe('equal', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          equal: 'Something'
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            equal: 'Something'
+          }
+        })(class User {});
+      });
 
       context('when value is equal', () => {
         it('is valid', () => {
@@ -91,12 +103,16 @@ describe('validation', () => {
 
     describe('empty', () => {
       describe('empty: true', () => {
-        const User = attributes({
-          name: {
-            type: String,
-            empty: true
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            name: {
+              type: String,
+              empty: true
+            }
+          })(class User {});
+        });
 
         context('when value is not empty', () => {
           it('is valid', () => {
@@ -120,12 +136,16 @@ describe('validation', () => {
       });
 
       describe('empty: false', () => {
-        const User = attributes({
-          name: {
-            type: String,
-            empty: false
-          }
-        })(class User {});
+        var User;
+
+        beforeEach(() => {
+          User = attributes({
+            name: {
+              type: String,
+              empty: false
+            }
+          })(class User {});
+        });
 
         context('when value is not empty', () => {
           it('is valid', () => {
@@ -151,12 +171,16 @@ describe('validation', () => {
     });
 
     describe('minLength', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          minLength: 3
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            minLength: 3
+          }
+        })(class User {});
+      });
 
       context('when value has minimum length', () => {
         it('is valid', () => {
@@ -180,12 +204,16 @@ describe('validation', () => {
     });
 
     describe('maxLength', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          maxLength: 4
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            maxLength: 4
+          }
+        })(class User {});
+      });
 
       context('when value has maximum length', () => {
         it('is valid', () => {
@@ -209,12 +237,16 @@ describe('validation', () => {
     });
 
     describe('exactLength', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          exactLength: 4
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            exactLength: 4
+          }
+        })(class User {});
+      });
 
       context('when value has exact length', () => {
         it('is valid', () => {
@@ -248,12 +280,16 @@ describe('validation', () => {
     });
 
     describe('regex', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          regex: /\w\d/
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            regex: /\w\d/
+          }
+        })(class User {});
+      });
 
       context('when value matches the regex', () => {
         it('is valid', () => {
@@ -277,12 +313,16 @@ describe('validation', () => {
     });
 
     describe('alphanumeric', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          alphanumeric: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            alphanumeric: true
+          }
+        })(class User {});
+      });
 
       context('when value is alphanumeric', () => {
         it('is valid', () => {
@@ -306,12 +346,16 @@ describe('validation', () => {
     });
 
     describe('lowerCase', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          lowerCase: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            lowerCase: true
+          }
+        })(class User {});
+      });
 
       context('when value is lower cased', () => {
         it('is valid', () => {
@@ -335,12 +379,16 @@ describe('validation', () => {
     });
 
     describe('upperCase', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          upperCase: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            upperCase: true
+          }
+        })(class User {});
+      });
 
       context('when value is upper cased', () => {
         it('is valid', () => {
@@ -364,12 +412,16 @@ describe('validation', () => {
     });
 
     describe('email', () => {
-      const User = attributes({
-        name: {
-          type: String,
-          email: true
-        }
-      })(class User {});
+      var User;
+
+      beforeEach(() => {
+        User = attributes({
+          name: {
+            type: String,
+            email: true
+          }
+        })(class User {});
+      });
 
       context('when value is a valid email', () => {
         it('is valid', () => {


### PR DESCRIPTION
Having the definitions outside Mocha blocks was making them being processed even when when using `describe.only`/`context.only`/`it.only` during debugs. This PR move all the definitions to inside `beforeEach` and `before` (when needed) blocks. The spec now is a little slower (from ~150ms to ~250ms) but it's not a big deal for now.