### PR TITLE
Remove a property lookup during validation

### DIFF
--- a/src/attributesDecorator.js
+++ b/src/attributesDecorator.js
@@ -7,8 +7,8 @@ const {
 } = require('./propertyDescriptors');
 
 const {
-  validationDescriptor,
-  staticValidationDescriptor
+  validationDescriptorForSchema,
+  staticValidationDescriptorForSchema
 } = require('./validation');
 
 const define = Object.defineProperty;
@@ -44,7 +44,7 @@ function attributesDecorator(declaredSchema) {
       value: declaredSchema
     });
 
-    define(WrapperClass, 'validate', staticValidationDescriptor);
+    define(WrapperClass, 'validate', staticValidationDescriptorForSchema(declaredSchema));
 
     define(WrapperClass.prototype, SCHEMA, {
       value: declaredSchema
@@ -65,7 +65,7 @@ function attributesDecorator(declaredSchema) {
       });
     });
 
-    define(WrapperClass.prototype, 'validate', validationDescriptor);
+    define(WrapperClass.prototype, 'validate', validationDescriptorForSchema(declaredSchema));
 
     define(WrapperClass.prototype, 'toJSON', serializationDescriptor);
 

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -58,25 +58,30 @@ exports.validationForSchema = function validationForSchema(schema) {
   };
 };
 
-exports.validationDescriptor = {
-  value: function validate() {
-    const validation = this[SCHEMA][VALIDATE];
-    const serializedStructure = this.toJSON();
+exports.validationDescriptorForSchema = function validationDescriptorForSchema(schema) {
+  const validation = schema[VALIDATE];
 
-    return validateData(validation, serializedStructure);
-  }
+  return {
+    value: function validate() {
+      const serializedStructure = this.toJSON();
+
+      return validateData(validation, serializedStructure);
+    }
+  };
 };
 
-exports.staticValidationDescriptor = {
-  value: function validate(data) {
-    if(data[SCHEMA]) {
-      data = data.toJSON();
+exports.staticValidationDescriptorForSchema = function staticValidationDescriptorForSchema(schema) {
+  const validation = schema[VALIDATE];
+
+  return {
+    value: function validate(data) {
+      if(data[SCHEMA]) {
+        data = data.toJSON();
+      }
+
+      return validateData(validation, data);
     }
-
-    const validation = this[SCHEMA][VALIDATE];
-
-    return validateData(validation, data);
-  }
+  };
 };
 
 function validateData(validation, data) {


### PR DESCRIPTION
This PR makes the process of validation faster removing the lookup for the structure schema.

Here's how the validation benchmark was _before_ the change (I ran it thrice due to possible variations):

```sh
> node benchmark/benchmark.js

# Validation:
With simple validation and is valid x 8,340 ops/sec ±2.08% (79 runs sampled)
With simple validation and is invalid x 4,573 ops/sec ±1.74% (81 runs sampled)
With nested validation and is valid x 5,687 ops/sec ±2.21% (79 runs sampled)
With nested validation and is invalid x 3,717 ops/sec ±2.07% (81 runs sampled)

=========

> node benchmark/benchmark.js

# Validation:
With simple validation and is valid x 8,596 ops/sec ±1.71% (83 runs sampled)
With simple validation and is invalid x 4,566 ops/sec ±1.94% (78 runs sampled)
With nested validation and is valid x 5,781 ops/sec ±1.77% (82 runs sampled)
With nested validation and is invalid x 3,735 ops/sec ±2.02% (79 runs sampled)

=========

> node benchmark/benchmark.js

# Validation:
With simple validation and is valid x 8,585 ops/sec ±1.67% (78 runs sampled)
With simple validation and is invalid x 4,565 ops/sec ±2.12% (80 runs sampled)
With nested validation and is valid x 5,784 ops/sec ±1.90% (82 runs sampled)
With nested validation and is invalid x 3,449 ops/sec ±3.12% (78 runs sampled)
```

And now after the change:

```sh
> node benchmark/benchmark.js

# Validation:
With simple validation and is valid x 8,816 ops/sec ±2.29% (80 runs sampled)
With simple validation and is invalid x 4,736 ops/sec ±5.27% (81 runs sampled)
With nested validation and is valid x 6,021 ops/sec ±1.87% (82 runs sampled)
With nested validation and is invalid x 4,002 ops/sec ±2.12% (82 runs sampled)

=========

> node benchmark/benchmark.js

# Validation:
With simple validation and is valid x 9,118 ops/sec ±2.11% (81 runs sampled)
With simple validation and is invalid x 4,947 ops/sec ±2.48% (81 runs sampled)
With nested validation and is valid x 5,923 ops/sec ±2.63% (80 runs sampled)
With nested validation and is invalid x 4,015 ops/sec ±2.09% (81 runs sampled)

=========

> node benchmark/benchmark.js

# Validation:
With simple validation and is valid x 8,593 ops/sec ±3.45% (77 runs sampled)
With simple validation and is invalid x 4,235 ops/sec ±5.33% (76 runs sampled)
With nested validation and is valid x 5,567 ops/sec ±2.25% (78 runs sampled)
With nested validation and is invalid x 3,547 ops/sec ±3.37% (76 runs sampled)
```

For most of the cases there were some improvement, I think it's worth it.