### PR TITLE
Allow circular reference

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,11 +5,16 @@
     "mocha": true
   },
   "extends": "eslint:recommended",
+  "plugins": [
+    "mocha"
+  ],
   "rules": {
     "comma-spacing": [2, { "before": false, "after": true }],
     "indent": [2, 2],
     "linebreak-style": [2, "unix"],
     "quotes": [2, "single"],
-    "semi": [2, "always"]
+    "semi": [2, "always"],
+    "mocha/no-exclusive-tests": 2,
+    "mocha/no-skipped-tests": 2
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - "6.1"
   - "6.0"
 script:
+  - npm run lint
   - npm test
   - npm run coveralls

--- a/benchmark/coercion.bm.js
+++ b/benchmark/coercion.bm.js
@@ -8,7 +8,7 @@ class FantasyBooksCollection extends Array { }
 class FriendsCollection extends Array { }
 class Item { }
 
-var User = attributes({
+const User = attributes({
   name: String,
   item: Item,
   favoriteBook: Book,
@@ -25,6 +25,8 @@ var User = attributes({
     itemType: String
   }
 })(class User { });
+
+const CircularUser = require('../test/fixtures/CircularUser');
 
 exports.name = 'Coercion';
 
@@ -64,6 +66,71 @@ exports.cases = [
         favoriteBook: {
           year: '2017'
         }
+      });
+    }
+  },
+  {
+    name: 'Primitive coercion with dynamic types',
+    fn() {
+      new CircularUser({
+        name: 50
+      });
+    }
+  },
+  {
+    name: 'Nested coercion with dynamic types [x1]',
+    fn() {
+      new CircularUser({
+        favoriteBook: {
+          name: 'A Study in Scarlet'
+        }
+      });
+    }
+  },
+  {
+    name: 'Nested coercion with dynamic types [x2]',
+    fn() {
+      new CircularUser({
+        favoriteBook: {
+          name: 1984
+        }
+      });
+    }
+  },
+  {
+    name: 'Nested coercion with dynamic types [x3]',
+    fn() {
+      new CircularUser({
+        friends: [
+          new CircularUser(),
+          new CircularUser()
+        ]
+      });
+    }
+  },
+  {
+    name: 'Nested coercion with dynamic types [x4]',
+    fn() {
+      new CircularUser({
+        friends: [
+          {},
+          {}
+        ]
+      });
+    }
+  },
+  {
+    name: 'Nested coercion with dynamic types [x5]',
+    fn() {
+      new CircularUser({
+        friends: [
+          {
+            favoriteBook: {}
+          },
+          {
+            favoriteBook: {}
+          }
+        ]
       });
     }
   },

--- a/benchmark/instantiation.bm.js
+++ b/benchmark/instantiation.bm.js
@@ -17,6 +17,9 @@ const Product = attributes({
   }
 })(class Product { });
 
+const CircularUser = require('../test/fixtures/CircularUser');
+const CircularBook = require('../test/fixtures/CircularBook');
+
 exports.name = 'Instantiation';
 
 exports.cases = [
@@ -47,6 +50,44 @@ exports.cases = [
           new User(),
           new User()
         ]
+      });
+    }
+  },
+  {
+    name: 'Simple instantiation with dynamic types',
+    fn() {
+      new CircularUser({
+        name: 'A name'
+      });
+    }
+  },
+  {
+    name: 'Complex instantiation with dynamic types [x1]',
+    fn() {
+      new CircularUser({
+        name: 'A name',
+        favoriteBook: new CircularBook({
+          name: 'A book'
+        })
+      });
+    }
+  },
+  {
+    name: 'Complex instantiation with dynamic types [x2]',
+    fn() {
+      new CircularUser({
+        name: 'A name',
+        friends: [
+          new CircularUser({
+            name: 'A friend'
+          }),
+          new CircularUser({
+            name: 'Another friend'
+          })
+        ],
+        favoriteBook: new CircularBook({
+          name: 'A book'
+        })
       });
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "chai": "^3.5.0",
     "coveralls": "^2.11.15",
     "eslint": "^3.8.1",
+    "eslint-plugin-mocha": "^4.8.0",
     "istanbul": "^0.4.5",
     "joi-browser": "^10.0.6",
     "karma": "^1.3.0",

--- a/src/attributesDecorator.js
+++ b/src/attributesDecorator.js
@@ -13,9 +13,9 @@ const {
 
 const define = Object.defineProperty;
 
-function attributesDecorator(declaredSchema) {
-  if(arguments.length > 1) {
-    const ErroneousPassedClass = arguments[1];
+function attributesDecorator(declaredSchema, schemaOptions = {}) {
+  if(typeof schemaOptions !== 'object') {
+    const ErroneousPassedClass = schemaOptions;
 
     const errorMessage = `You passed the structure class as the second parameter of attributes(). The expected usage is \`attributes(schema)(${ ErroneousPassedClass.name || 'StructureClass' })\`.`;
 
@@ -34,7 +34,7 @@ function attributesDecorator(declaredSchema) {
       }
     });
 
-    declaredSchema = normalizeSchema(declaredSchema);
+    declaredSchema = normalizeSchema(declaredSchema, schemaOptions);
 
     if(WrapperClass[SCHEMA]) {
       declaredSchema = Object.assign({}, WrapperClass[SCHEMA], declaredSchema);

--- a/src/schemaNormalization.js
+++ b/src/schemaNormalization.js
@@ -26,7 +26,7 @@ function normalizeAttribute(schemaOptions, attribute, attributeName) {
     }
 
     if (typeof attribute.type === 'string') {
-      if(!schemaOptions.dynamics[attribute.type]) {
+      if(!schemaOptions.dynamics || !schemaOptions.dynamics[attribute.type]) {
         throw new Error(`There is no dynamic type for attribute: ${ attributeName }.`);
       }
 

--- a/src/schemaNormalization.js
+++ b/src/schemaNormalization.js
@@ -2,43 +2,11 @@ const { coercionFor } = require('./typeCoercion');
 const { validationForAttribute, validationForSchema } = require('./validation');
 const { VALIDATE } = require('./symbols');
 
-function normalizeAttribute(attribute, attributeName) {
-  switch(typeof attribute) {
-  case 'object':
-    if(!attribute.type) {
-      throw new Error(`Missing type for attribute: ${ attributeName }.`);
-    }
-
-    if(typeof attribute.type !== 'function') {
-      throw new TypeError(`Attribute type must be a constructor: ${ attributeName }.`);
-    }
-
-    if(attribute.itemType) {
-      attribute.itemType = normalizeAttribute(attribute.itemType, 'itemType');
-    }
-
-    return Object.assign({}, attribute, {
-      coerce: coercionFor(attribute, attribute.itemType),
-      validation: validationForAttribute(attribute)
-    });
-
-  case 'function':
-    var normalizedType = { type: attribute };
-    normalizedType.coerce = coercionFor(normalizedType);
-    normalizedType.validation = validationForAttribute(normalizedType);
-
-    return normalizedType;
-
-  default:
-    throw new TypeError(`Invalid type for attribute: ${ attributeName }.`);
-  }
-}
-
-function normalizeSchema(rawSchema) {
+function normalizeSchema(rawSchema, schemaOptions) {
   const schema = Object.create(null);
 
   Object.keys(rawSchema).forEach((attributeName) => {
-    schema[attributeName] = normalizeAttribute(rawSchema[attributeName], attributeName);
+    schema[attributeName] = normalizeAttribute(schemaOptions, rawSchema[attributeName], attributeName);
   });
 
   const schemaValidation = validationForSchema(schema);
@@ -47,8 +15,43 @@ function normalizeSchema(rawSchema) {
     value: schemaValidation
   });
 
-
   return schema;
+}
+
+function normalizeAttribute(schemaOptions, attribute, attributeName) {
+  switch(typeof attribute) {
+  case 'object':
+    if(!attribute.type) {
+      throw new Error(`Missing type for attribute: ${ attributeName }.`);
+    }
+
+    if (typeof attribute.type === 'string') {
+      if(!schemaOptions.dynamics[attribute.type]) {
+        throw new Error(`There is no dynamic type for attribute: ${ attributeName }.`);
+      }
+
+      attribute.getType = schemaOptions.dynamics[attribute.type];
+      attribute.dynamicType = true;
+    } else if(typeof attribute.type !== 'function') {
+      throw new TypeError(`Attribute type must be a constructor: ${ attributeName }.`);
+    }
+
+    if(attribute.itemType) {
+      attribute.itemType = normalizeAttribute(schemaOptions, attribute.itemType, 'itemType');
+    }
+
+    return Object.assign({}, attribute, {
+      coerce: coercionFor(attribute, attribute.itemType),
+      validation: validationForAttribute(attribute)
+    });
+
+  case 'function':
+  case 'string':
+    return normalizeAttribute(schemaOptions, { type: attribute }, attributeName);
+
+  default:
+    throw new TypeError(`Invalid type for attribute: ${ attributeName }.`);
+  }
 }
 
 exports.normalizeSchema = normalizeSchema;

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -1,4 +1,5 @@
 const { SCHEMA } = require('./symbols');
+const { getType } = require('./typeResolver');
 
 function serialize(structure) {
   if(structure === undefined) {
@@ -17,9 +18,9 @@ function serialize(structure) {
 
     let serializedValue;
 
-    if(schema[attrName].itemType && schema[attrName].itemType.type[SCHEMA] !== undefined) {
+    if(schema[attrName].itemType && getTypeSchema(schema[attrName].itemType)) {
       serializedValue = attribute.map(serialize);
-    } else if(schema[attrName].type[SCHEMA] !== undefined) {
+    } else if(getTypeSchema(schema[attrName])) {
       serializedValue = serialize(attribute);
     } else {
       serializedValue = attribute;
@@ -29,6 +30,10 @@ function serialize(structure) {
   }
 
   return serializedStructure;
+}
+
+function getTypeSchema(typeDescriptor) {
+  return getType(typeDescriptor)[SCHEMA];
 }
 
 exports.serialize = serialize;

--- a/src/typeCoercion/array.js
+++ b/src/typeCoercion/array.js
@@ -1,4 +1,5 @@
 const { ARRAY_OR_ITERABLE } = require('../errorMessages');
+const { getType } = require('../typeResolver');
 
 module.exports = function arrayCoercionFor(typeDescriptor, itemTypeDescriptor) {
   return function coerceArray(value) {
@@ -14,7 +15,8 @@ module.exports = function arrayCoercionFor(typeDescriptor, itemTypeDescriptor) {
       value = Array(...value);
     }
 
-    const coercedValue = new typeDescriptor.type();
+    const type = getType(typeDescriptor);
+    const coercedValue = new type();
 
     for(let i = 0; i < value.length; i++) {
       coercedValue.push(itemTypeDescriptor.coerce(value[i]));

--- a/src/typeCoercion/generic.js
+++ b/src/typeCoercion/generic.js
@@ -4,10 +4,18 @@ module.exports = function genericCoercionFor(typeDescriptor) {
       return;
     }
 
-    if(value instanceof typeDescriptor.type) {
+    var type;
+
+    if(typeDescriptor.dynamicType) {
+      type = typeDescriptor.getType();
+    } else {
+      type = typeDescriptor.type;
+    }
+
+    if(value instanceof type) {
       return value;
     }
 
-    return new typeDescriptor.type(value);
+    return new type(value);
   };
 };

--- a/src/typeCoercion/generic.js
+++ b/src/typeCoercion/generic.js
@@ -1,16 +1,12 @@
+const { getType } = require('../typeResolver');
+
 module.exports = function genericCoercionFor(typeDescriptor) {
   return function coerce(value) {
     if(value === undefined) {
       return;
     }
 
-    var type;
-
-    if(typeDescriptor.dynamicType) {
-      type = typeDescriptor.getType();
-    } else {
-      type = typeDescriptor.type;
-    }
+    const type = getType(typeDescriptor);
 
     if(value instanceof type) {
       return value;

--- a/src/typeResolver.js
+++ b/src/typeResolver.js
@@ -1,0 +1,7 @@
+exports.getType = function getType(typeDescriptor) {
+  if(typeDescriptor.dynamicType) {
+    return typeDescriptor.getType();
+  }
+
+  return typeDescriptor.type;
+};

--- a/src/validation/nested.js
+++ b/src/validation/nested.js
@@ -3,14 +3,17 @@ const { SCHEMA } = require('../symbols');
 
 module.exports = function nestedValidation(typeDescriptor) {
   var joiSchema = joi.object();
-  var typeSchema = typeDescriptor.type[SCHEMA];
 
-  if(typeSchema !== undefined) {
-    var nestedValidations = {};
+  if(typeDescriptor.dynamicType) {
 
-    Object.keys(typeSchema).forEach((v) => {
-      nestedValidations[v] = typeSchema[v].validation;
-    });
+  } else {
+    const typeSchema = typeDescriptor.type[SCHEMA];
+
+    const nestedValidations = Object.keys(typeSchema)
+      .reduce((validations, v) => {
+        validations[v] = typeSchema[v].validation;
+        return validations;
+      }, {});
 
     joiSchema = joiSchema.keys(nestedValidations);
   }

--- a/src/validation/nested.js
+++ b/src/validation/nested.js
@@ -1,5 +1,6 @@
 const joi = require('joi');
 const { SCHEMA } = require('../symbols');
+const { requiredOption } = require('./utils');
 
 module.exports = function nestedValidation(typeDescriptor) {
   if(typeDescriptor.dynamicType) {
@@ -9,9 +10,9 @@ module.exports = function nestedValidation(typeDescriptor) {
   const typeSchema = typeDescriptor.type[SCHEMA];
   var joiSchema = getNestedValidations(typeSchema);
 
-  if(typeDescriptor.required) {
-    joiSchema = joiSchema.required();
-  }
+  joiSchema = requiredOption(typeDescriptor, {
+    initial: joiSchema
+  });
 
   return joiSchema;
 };
@@ -23,9 +24,9 @@ function validationToDynamicType(typeDescriptor) {
     return getNestedValidations(typeSchema);
   });
 
-  if(typeDescriptor.required) {
-    joiSchema = joiSchema.required();
-  }
+  joiSchema = requiredOption(typeDescriptor, {
+    initial: joiSchema
+  });
 
   return joiSchema;
 }

--- a/src/validation/utils.js
+++ b/src/validation/utils.js
@@ -52,3 +52,11 @@ exports.equalOption = function equalOption(typeDescriptor, { initial }) {
 
   return initial.equal(possibilities);
 };
+
+exports.requiredOption = function requiredOption(typeDescriptor, { initial }) {
+  if(typeDescriptor.required) {
+    return initial.required();
+  }
+
+  return initial;
+}

--- a/src/validation/utils.js
+++ b/src/validation/utils.js
@@ -59,4 +59,4 @@ exports.requiredOption = function requiredOption(typeDescriptor, { initial }) {
   }
 
   return initial;
-}
+};

--- a/test/fixtures/BooksCollection.js
+++ b/test/fixtures/BooksCollection.js
@@ -1,0 +1,1 @@
+module.exports = class BooksCollection extends Array {}

--- a/test/fixtures/BooksCollection.js
+++ b/test/fixtures/BooksCollection.js
@@ -1,1 +1,1 @@
-module.exports = class BooksCollection extends Array {}
+module.exports = class BooksCollection extends Array {};

--- a/test/fixtures/BrokenCircularBook.js
+++ b/test/fixtures/BrokenCircularBook.js
@@ -1,0 +1,10 @@
+const { attributes } = require('../../src');
+
+const Book = attributes({
+  name: String,
+  owner: 'User'
+}, {
+  dynamics: { }
+})(class Book { });
+
+module.exports = Book;

--- a/test/fixtures/CircularBook.js
+++ b/test/fixtures/CircularBook.js
@@ -1,0 +1,14 @@
+const { attributes } = require('../../src');
+
+const Book = attributes({
+  name: String,
+  owner: 'User',
+  nextBook: 'Book'
+}, {
+  dynamics: {
+    User: () => require('./CircularUser'),
+    Book: () => Book
+  }
+})(class Book { });
+
+module.exports = Book;

--- a/test/fixtures/CircularUser.js
+++ b/test/fixtures/CircularUser.js
@@ -1,0 +1,20 @@
+const { attributes } = require('../../src');
+
+const User = attributes({
+  name: String,
+  friends: {
+    type: Array,
+    itemType: 'User'
+  },
+  favoriteBook: {
+    type: 'Book',
+    required: true
+  }
+}, {
+  dynamics: {
+    User: () => User,
+    Book: () => require('./CircularBook')
+  }
+})(class User { });
+
+module.exports = User;

--- a/test/fixtures/CircularUser.js
+++ b/test/fixtures/CircularUser.js
@@ -9,11 +9,16 @@ const User = attributes({
   favoriteBook: {
     type: 'Book',
     required: true
+  },
+  books: {
+    type: 'BooksCollection',
+    itemType: String
   }
 }, {
   dynamics: {
     User: () => User,
-    Book: () => require('./CircularBook')
+    Book: () => require('./CircularBook'),
+    BooksCollection: () => require('./BooksCollection')
   }
 })(class User { });
 

--- a/test/unit/creatingStructureClass.spec.js
+++ b/test/unit/creatingStructureClass.spec.js
@@ -82,7 +82,7 @@ describe('creating a structure class', () => {
     });
   });
 
-  describe.only('when using dynamic attribute types', () => {
+  describe('when using dynamic attribute types', () => {
     it('allows to use dynamic values without breaking', () => {
       require('../fixtures/CircularUser');
       require('../fixtures/CircularBook');

--- a/test/unit/creatingStructureClass.spec.js
+++ b/test/unit/creatingStructureClass.spec.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const { attributes } = require('../../src');
 
-describe('creating an structure class', () => {
+describe('creating a structure class', () => {
   describe('structure class is passed as the second parameter', () => {
     context('when structure class has a name', () => {
       it('throws with a message with structure class name', () => {
@@ -24,7 +24,6 @@ describe('creating an structure class', () => {
       });
     });
   });
-
 
   describe('using class static methods and properties', () => {
     var User;
@@ -80,6 +79,19 @@ describe('creating an structure class', () => {
 
         expect(user.age).to.equal(18);
       });
+    });
+  });
+
+  describe.only('when using dynamic attribute types', () => {
+    it('allows to use dynamic values without breaking', () => {
+      require('../fixtures/CircularUser');
+      require('../fixtures/CircularBook');
+    });
+
+    it('breaks if there is no value for dynamic type', () => {
+      expect(() => {
+        require('../fixtures/BrokenCircularBook');
+      }).to.throw(Error, 'There is no dynamic type for attribute: owner');
     });
   });
 });

--- a/test/unit/instanceAndUpdate.spec.js
+++ b/test/unit/instanceAndUpdate.spec.js
@@ -61,7 +61,7 @@ describe('instantiating a structure', () => {
   });
 });
 
-describe.only('instantiating a structure with dynamic attribute types', () => {
+describe('instantiating a structure with dynamic attribute types', () => {
   var CircularUser;
   var CircularBook;
 
@@ -153,7 +153,7 @@ describe('updating an instance', () => {
   });
 });
 
-describe.only('updating a structure with dynamic attribute types', () => {
+describe('updating a structure with dynamic attribute types', () => {
   var CircularUser;
   var CircularBook;
 

--- a/test/unit/instanceAndUpdate.spec.js
+++ b/test/unit/instanceAndUpdate.spec.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const { attributes } = require('../../src');
 
-describe('instantiating an structure', () => {
+describe('instantiating a structure', () => {
   var User;
 
   beforeEach(() => {
@@ -58,6 +58,38 @@ describe('instantiating an structure', () => {
 
     expect(user.name).to.equal('Self');
     expect(user.attributes.name).to.equal('Self');
+  });
+});
+
+describe.only('instantiating a structure with dynamic attribute types', () => {
+  var CircularUser;
+  var CircularBook;
+
+  beforeEach(() => {
+    CircularUser = require('../fixtures/CircularUser');
+    CircularBook = require('../fixtures/CircularBook');
+  });
+
+  it('creates instance properly', () => {
+    const userOne = new CircularUser({
+      name: 'Circular user one',
+      friends: [],
+      favoriteBook: new CircularBook({
+        name: 'Brave new world',
+        owner: new CircularUser()
+      })
+    });
+
+    const userTwo = new CircularUser({
+      name: 'Circular user two',
+      friends: [userOne]
+    });
+
+    expect(userOne).to.be.instanceOf(CircularUser);
+    expect(userOne.favoriteBook).to.be.instanceOf(CircularBook);
+    expect(userOne.favoriteBook.owner).to.be.instanceOf(CircularUser);
+    expect(userTwo).to.be.instanceOf(CircularUser);
+    expect(userTwo.friends[0]).to.be.instanceOf(CircularUser);
   });
 });
 
@@ -118,5 +150,33 @@ describe('updating an instance', () => {
     expect(() => {
       user.attributes = null;
     }).to.throw(TypeError, /^#attributes can't be set to a non-object\.$/);
+  });
+});
+
+describe.only('updating a structure with dynamic attribute types', () => {
+  var CircularUser;
+  var CircularBook;
+
+  beforeEach(() => {
+    CircularUser = require('../fixtures/CircularUser');
+    CircularBook = require('../fixtures/CircularBook');
+  });
+
+  it('updates instance attribute when assigned a new value', () => {
+    const user = new CircularUser({
+      favoriteBook: new CircularBook({
+        name: 'Brave new world',
+        owner: new CircularUser()
+      })
+    });
+
+    user.favoriteBook = new CircularBook({
+      name: '1984',
+      owner: user
+    });
+
+    expect(user.favoriteBook).to.be.instanceOf(CircularBook);
+    expect(user.favoriteBook.owner).to.be.instanceOf(CircularUser);
+    expect(user.favoriteBook.owner).to.equal(user);
   });
 });

--- a/test/unit/schemaNormalization.spec.js
+++ b/test/unit/schemaNormalization.spec.js
@@ -39,7 +39,7 @@ describe('schema normalization', () => {
   context('when it is not possible to normalize the attribute', () => {
     context('when attribute type is not an object nor a constructor', () => {
       it('throws an error', () => {
-        const schema = { name: 'invalid attribute' };
+        const schema = { name: true };
 
         expect(() => {
           normalizeSchema(schema);
@@ -51,7 +51,7 @@ describe('schema normalization', () => {
       it('throws an error', () => {
         const schema = {
           name: {
-            type: 'invalid attribute'
+            type: true
           }
         };
 

--- a/test/unit/schemaNormalization.spec.js
+++ b/test/unit/schemaNormalization.spec.js
@@ -76,7 +76,7 @@ describe('schema normalization', () => {
       });
     });
 
-    context('when itemType is an constructor', () => {
+    context('when itemType is a constructor', () => {
       it('normalizes itemType to an object with type field being equal to passed constructor', () => {
         const schema = {
           name: {

--- a/test/unit/serialization/nestedStructure.spec.js
+++ b/test/unit/serialization/nestedStructure.spec.js
@@ -80,4 +80,74 @@ describe('serialization', () => {
       });
     });
   });
+
+  describe('Nested structure with dynamic attribute types', () => {
+    var CircularUser;
+    var CircularBook;
+
+    beforeEach(() => {
+      CircularUser = require('../../fixtures/CircularUser');
+      CircularBook = require('../../fixtures/CircularBook');
+    });
+
+    context('when all data is present', () => {
+      it('include all data defined on schema', () => {
+        const user = new CircularUser({
+          name: 'Something',
+          friends: [
+            new CircularUser({
+              name: 'Friend 1',
+              favoriteBook: new CircularBook({ name: 'Book 1' })
+            }),
+            new CircularUser({
+              name: 'Friend 2',
+              favoriteBook: new CircularBook({ name: 'Book 2'})
+            })
+          ],
+          favoriteBook: new CircularBook({ name: 'The Book'})
+        });
+
+        expect(user.toJSON()).to.eql({
+          name: 'Something',
+          friends: [
+            {
+              name: 'Friend 1',
+              favoriteBook: { name: 'Book 1' }
+            },
+            {
+              name: 'Friend 2',
+              favoriteBook: { name: 'Book 2'}
+            }
+          ],
+          favoriteBook: { name: 'The Book' }
+        });
+      });
+    });
+
+    context('when nested structure is missing', () => {
+      it('does not set a key for missing structure', () => {
+        const user = new CircularUser({
+          name: 'Something'
+        });
+
+        expect(user.toJSON()).to.eql({
+          name: 'Something'
+        });
+      });
+    });
+
+    context('when some attribute on nested structure is missing', () => {
+      it('does not set a key for missing nested attribute', () => {
+        const user = new CircularUser({
+          name: 'Something',
+          favoriteBook: new CircularBook({})
+        });
+
+        expect(user.toJSON()).to.eql({
+          name: 'Something',
+          favoriteBook: {}
+        });
+      });
+    });
+  });
 });

--- a/test/unit/subclassingStructureClass.spec.js
+++ b/test/unit/subclassingStructureClass.spec.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const { attributes } = require('../../src');
 
-describe('subclassing an structure with a POJO class', () => {
+describe('subclassing a structure with a POJO class', () => {
   var User;
   var Admin;
 
@@ -31,7 +31,7 @@ describe('subclassing an structure with a POJO class', () => {
     };
   });
 
-  describe('instantiating an structure subclass', () => {
+  describe('instantiating a structure subclass', () => {
     it('is instance of class and superclass', () => {
       const admin = new Admin({
         name: 'The Admin'
@@ -153,7 +153,7 @@ describe('subclassing an structure with a POJO class', () => {
   });
 });
 
-describe('subclassing an structure with another structure', () => {
+describe('subclassing a structure with another structure', () => {
   var Admin;
   var User;
 

--- a/test/unit/typeCoercion/array.spec.js
+++ b/test/unit/typeCoercion/array.spec.js
@@ -118,4 +118,50 @@ describe('type coercion', () => {
       });
     });
   });
+
+  describe('Array from dynamic type', () => {
+    var CircularUser;
+    var BooksCollection;
+
+    beforeEach(() => {
+      CircularUser = require('../../fixtures/CircularUser');
+      BooksCollection = require('../../fixtures/BooksCollection');
+    });
+
+    it('coerces collection', () => {
+      const user = new CircularUser({
+        books: [
+          'Dragons of Ether',
+          'The Dark Tower'
+        ]
+      });
+
+      expect(user.books).to.be.instanceOf(BooksCollection);
+    });
+
+    it('coerces items', () => {
+      const user = new CircularUser({
+        books: ['The Lord of The Rings', 1984, true]
+      });
+
+      expect(user.books).to.eql([
+        'The Lord of The Rings',
+        '1984',
+        'true'
+      ]);
+    });
+
+    it('does not coerce items that are of the expected type', () => {
+      const book = new String('A Game of Thrones');
+
+      const user = new CircularUser({
+        books: [book]
+      });
+
+      expect(user.books).to.eql([
+        new String('A Game of Thrones')
+      ]);
+      expect(user.books[0]).to.equal(book);
+    });
+  });
 });

--- a/test/unit/typeCoercion/arraySubclass.spec.js
+++ b/test/unit/typeCoercion/arraySubclass.spec.js
@@ -7,7 +7,7 @@ describe('type coercion', () => {
     var User;
 
     beforeEach(() => {
-      Collection = class Collection extends Array {}
+      Collection = class Collection extends Array {};
 
       User = attributes({
         books: {

--- a/test/unit/typeCoercion/pojo.spec.js
+++ b/test/unit/typeCoercion/pojo.spec.js
@@ -12,7 +12,7 @@ describe('type coercion', () => {
           this.x = x;
           this.y = y;
         }
-      }
+      };
 
       User = attributes({
         location: Location

--- a/test/unit/typeCoercion/structure.spec.js
+++ b/test/unit/typeCoercion/structure.spec.js
@@ -54,7 +54,7 @@ describe('type coercion', () => {
     });
   });
 
-  describe.only('Structure class with dynamic attribute types', () => {
+  describe('Structure class with dynamic attribute types', () => {
     var CircularUser;
     var CircularBook;
 

--- a/test/unit/typeCoercion/structure.spec.js
+++ b/test/unit/typeCoercion/structure.spec.js
@@ -53,4 +53,57 @@ describe('type coercion', () => {
       expect(user.location.y).to.equal(2);
     });
   });
+
+  describe.only('Structure class with dynamic attribute types', () => {
+    var CircularUser;
+    var CircularBook;
+
+    beforeEach(() => {
+      CircularUser = require('../../fixtures/CircularUser');
+      CircularBook = require('../../fixtures/CircularBook');
+    });
+
+    it('creates instance properly', () => {
+      const userOne = new CircularUser({
+        name: 'Circular user one',
+        friends: [],
+        favoriteBook: {
+          name: 'The Silmarillion',
+          owner: {}
+        }
+      });
+
+      const userTwo = new CircularUser({
+        name: 'Circular user two',
+        friends: [userOne]
+      });
+
+      expect(userOne).to.be.instanceOf(CircularUser);
+      expect(userOne.favoriteBook).to.be.instanceOf(CircularBook);
+      expect(userOne.favoriteBook.owner).to.be.instanceOf(CircularUser);
+      expect(userTwo).to.be.instanceOf(CircularUser);
+      expect(userTwo.friends[0]).to.be.instanceOf(CircularUser);
+    });
+
+    it('coerces when updating the value', () => {
+      const user = new CircularUser({
+        favoriteBook: {
+          name: 'The Silmarillion',
+          owner: {}
+        }
+      });
+
+      user.favoriteBook = {
+        name: 'The World of Ice & Fire',
+        owner: {
+          name: 'New name'
+        }
+      };
+
+      expect(user.favoriteBook).to.be.instanceOf(CircularBook);
+      expect(user.favoriteBook.name).to.equal('The World of Ice & Fire');
+      expect(user.favoriteBook.owner).to.be.instanceOf(CircularUser);
+      expect(user.favoriteBook.owner.name).to.equal('New name');
+    });
+  });
 });

--- a/test/unit/validation/array.spec.js
+++ b/test/unit/validation/array.spec.js
@@ -190,11 +190,9 @@ describe('validation', () => {
 
     describe('nested validation with dynamic attribute types', () => {
       var CircularUser;
-      var CircularBook;
 
       beforeEach(() => {
         CircularUser = require('../../fixtures/CircularUser');
-        CircularBook = require('../../fixtures/CircularBook');
       });
 
       context('when nested value is present', () => {

--- a/test/unit/validation/array.spec.js
+++ b/test/unit/validation/array.spec.js
@@ -188,6 +188,47 @@ describe('validation', () => {
       });
     });
 
+    describe('nested validation with dynamic attribute types', () => {
+      var CircularUser;
+      var CircularBook;
+
+      beforeEach(() => {
+        CircularUser = require('../../fixtures/CircularUser');
+        CircularBook = require('../../fixtures/CircularBook');
+      });
+
+      context('when nested value is present', () => {
+        it('is valid', () => {
+          const user = new CircularUser({
+            friends: [
+              new CircularUser({
+                favoriteBook: {}
+              })
+            ],
+            favoriteBook: {}
+          });
+
+          assertValid(user);
+        });
+      });
+
+      context('when nested value is not present', () => {
+        it('is not valid and has errors set', () => {
+          const user = new CircularUser({
+            friends: [
+              new CircularUser({
+                favoriteBook: {}
+              }),
+              new CircularUser()
+            ],
+            favoriteBook: {}
+          });
+
+          assertInvalid(user, 'friends.1.favoriteBook');
+        });
+      });
+    });
+
     describe('minLength', () => {
       var User;
 

--- a/test/unit/validation/nestedPojo.spec.js
+++ b/test/unit/validation/nestedPojo.spec.js
@@ -8,7 +8,7 @@ describe('validation', () => {
       var User;
 
       beforeEach(() => {
-        Location = class Location {}
+        Location = class Location {};
 
         User = attributes({
           lastLocation: {
@@ -43,7 +43,7 @@ describe('validation', () => {
       var User;
 
       beforeEach(() => {
-        Location = class Location {}
+        Location = class Location {};
 
         User = attributes({
           lastLocation: {

--- a/test/unit/validation/nestedStructure.spec.js
+++ b/test/unit/validation/nestedStructure.spec.js
@@ -133,4 +133,81 @@ describe('validation', () => {
       });
     });
   });
+
+  describe.only('Nested with structure class with dynamic attribute types', () => {
+    var CircularUser;
+    var CircularBook;
+
+    beforeEach(() => {
+      CircularUser = require('../../fixtures/CircularUser');
+      CircularBook = require('../../fixtures/CircularBook');
+    });
+
+    describe('no validation', () => {
+      context('when value is present', () => {
+        it('is valid', () => {
+          const user = new CircularUser({
+            friends: [],
+            favoriteBook: {}
+          });
+
+          assertValid(user);
+        });
+      });
+
+      context('when value is not present', () => {
+        it('is valid', () => {
+          const user = new CircularUser({
+            favoriteBook: {}
+          });
+
+          assertValid(user);
+        });
+      });
+    });
+
+    describe('required', () => {
+      context('when value is present', () => {
+        it('is valid', () => {
+          const user = new CircularUser({
+            favoriteBook: {}
+          });
+
+          assertValid(user);
+        });
+      });
+
+      context('when value is not present', () => {
+        it('is invalid', () => {
+          const user = new CircularUser();
+
+          assertInvalid(user, 'favoriteBook');
+        });
+      });
+    });
+
+    describe('nested required', () => {
+      context('when value is present', () => {
+        it('is valid', () => {
+          const book = new CircularBook({
+            owner: {
+              favoriteBook: new CircularBook()
+            }
+          });
+
+          assertValid(book);
+        });
+      });
+
+      context('when value is not present', () => {
+        it('is invalid', () => {
+          const book = new CircularBook({
+            owner: new CircularUser()
+          });
+
+          assertInvalid(book, 'favoriteBook');
+        });
+      });
+    });
+  });
 });

--- a/test/unit/validation/nestedStructure.spec.js
+++ b/test/unit/validation/nestedStructure.spec.js
@@ -134,7 +134,7 @@ describe('validation', () => {
     });
   });
 
-  describe.only('Nested with structure class with dynamic attribute types', () => {
+  describe('Nested with structure class with dynamic attribute types', () => {
     var CircularUser;
     var CircularBook;
 
@@ -205,7 +205,7 @@ describe('validation', () => {
             owner: new CircularUser()
           });
 
-          assertInvalid(book, 'favoriteBook');
+          assertInvalid(book, 'owner.favoriteBook');
         });
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,6 +1223,12 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-mocha@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-4.8.0.tgz#7627b35a61e5a720412da96eab06f0e03a1dcdb6"
+  dependencies:
+    ramda "^0.22.1"
+
 eslint@^3.8.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.13.1.tgz#564d2646b5efded85df96985332edd91a23bff25"
@@ -2588,6 +2594,10 @@ querystring-es3@^0.2.0:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+ramda@^0.22.1:
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.22.1.tgz#031da0c3df417c5b33c96234757eb37033f36a0e"
 
 randomatic@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
Closes #23 

This PR adds a second parameter to the `attributes` function, that allows options to be passed to the function besides the schema. In this new parameter it's possible to pass a `dynamics` option, where we'll be able to specify functions that return dynamic types (that will be declared in the schema as a string), like this:

```javascript
const User = attributes({
  name: String,
  friends: {
    type: Array,
    itemType: 'User' // << dynamic type name
  },
  favoriteBook: {
    type: 'Book', // << dynamic type name
    required: true
  },
  books: {
    type: 'BooksCollection', // << dynamic type name
    itemType: String
  }
}, {
  dynamics: { // << dynamic types values
    User: () => User,
    Book: () => require('./CircularBook'),
    BooksCollection: () => require('./BooksCollection')
  }
})(class User { });
```

Dues to the way Node resolves circular dependencies __it's necessary__ to put the `require` block inside the function that returns the dynamic type, also it will make it __not possible__ to use `import` for those dependencies, so we have to document that as well.

The validation for those dynamic types use a method from joi called [lazy](https://github.com/hapijs/joi/blob/v10.2.0/API.md#lazyfn).