### PR TITLE
Test against node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "node"
   - "6.1"
   - "6.0"
+  - "8.0"
 script:
   - npm run lint
   - npm test

--- a/test/unit/coercion/date.spec.js
+++ b/test/unit/coercion/date.spec.js
@@ -41,7 +41,7 @@ describe('type coercion', () => {
         birth: null
       });
 
-      expect(user.birth).to.eql(new Date('1970-01-01T00:00:00'));
+      expect(user.birth).to.eql(new Date('1970-01-01T00:00:00Z'));
     });
   });
 });


### PR DESCRIPTION
This simply tells travis to also test against node 8.

Only needed one change to the tests: In node 8, the [`Z`](https://en.wikipedia.org/wiki/ISO_8601#UTC) is necessary to designate UTC. Otherwise, that date gets created in your local timezone and the test fails.