### PR TITLE
Fix subclass schema validation

### DIFF
--- a/src/attributes/decorator.js
+++ b/src/attributes/decorator.js
@@ -28,11 +28,11 @@ function attributesDecorator(schema, schemaOptions = {}) {
       }
     });
 
-    schema = Schema.normalize(schema, schemaOptions);
-
     if(WrapperClass[SCHEMA]) {
       schema = Object.assign({}, WrapperClass[SCHEMA], schema);
     }
+
+    schema = Schema.normalize(schema, schemaOptions);
 
     define(WrapperClass, SCHEMA, {
       value: schema

--- a/test/unit/validation/structureSubclass.spec.js
+++ b/test/unit/validation/structureSubclass.spec.js
@@ -1,0 +1,56 @@
+const { attributes } = require('../../../src');
+const { assertValid, assertInvalid } = require('../../support/validationMatchers');
+
+describe('validation', () => {
+  describe('structure subclass', () => {
+    var Admin;
+    var User;
+
+    beforeEach(() => {
+      User = attributes({
+        name: {
+          type: String,
+          required: true
+        }
+      })(class User {});
+
+      Admin = attributes({
+        level: {
+          type: Number,
+          required: true
+        }
+      })(class Admin extends User {});
+    });
+
+    context('with invalid superclass schema', () => {
+      it('is invalid', () => {
+        const admin = new Admin({
+          level: 3
+        });
+
+        assertInvalid(admin, 'name');
+      });
+    });
+
+    context('with invalid subclass schema', () => {
+      it('is invalid', () => {
+        const admin = new Admin({
+          name: 'The admin'
+        });
+
+        assertInvalid(admin, 'level');
+      });
+    });
+
+    context('with valid superclass and subclass schema', () => {
+      it('is valid', () => {
+        const admin = new Admin({
+          name: 'The admin',
+          level: 3
+        });
+
+        assertValid(admin);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Currently, when trying to subclass a structure, the subclass does not receive a `validate()` method since the schemas are combined after the non-enumerable validate method is assigned to the subclass schema. This corrects the order of the two so that the schemas are combined first and then normalized afterwards.

Fixes #48.