### PR TITLE
Add BattleCry generators to facilitate creating/updating schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Be aware that not the whole test suite will pass on browsers, there are some cas
 
 Right now 95.5% of the tests will pass on Chrome 55, and 95% will pass on Firefox 45. We intend to make it support older versions using polyfills in the next releases.
 
+## BattleCry generators
+
+There are configurable [BattleCry](https://github.com/pedsmoreira/battlecry) generators ready to be downloaded and help scaffolding schema:
+
+```sh
+npm install -g battlecry
+cry download generator talyssonoc/structure
+cry g schema user name age:int:required cars:string[] favoriteBook:book friends:user[]:default :updateAge
+```
+
+Run `cry --help` to check more info about the generators available;
+
 ## [Contributing](/contributing.md)
 
 ## [LICENSE](/license.md)

--- a/battlecry/generators/schema/Attribute.js
+++ b/battlecry/generators/schema/Attribute.js
@@ -1,0 +1,71 @@
+import { casex } from 'battlecry';
+
+const ALIASES = {
+  Number: ["int", "integer"],
+  String: ["text"],
+  Boolean: ["bool"]
+};
+
+export default class Attribute {
+  constructor(value) {
+    const [name, type, ...modifiers] = value.split(":");
+    this.name = name;
+    this.type = type || "string";
+    this.modifiers = modifiers;
+  }
+
+  static alias(type) {
+    const lowerType = type.toLowerCase();
+    const keys = Object.keys(ALIASES);
+
+    const alias = keys.find(key => {
+      return ALIASES[key].find(
+        alias => alias.toLowerCase() === lowerType
+      );
+    });
+
+    return alias || casex(type, 'NaMe');
+  }
+
+  get aliasedType() {
+    return this.array ? "Array" : this.itemType;
+  }
+
+  get itemType() {
+    return Attribute.alias(this.type.split("[]")[0]);
+  }
+
+  get required() {
+    return this.modifiers.includes("required");
+  }
+
+  get default() {
+    return this.modifiers.includes("default");
+  }
+
+  get array() {
+    return this.type.includes("[]");
+  }
+
+  get complex() {
+    return this.array || this.required || this.default;
+  }
+
+  get text() {
+    if (!this.complex) return `  __naMe__: ${this.aliasedType},`;
+
+    this.contents = [];
+    this.push("  __naMe__: {");
+    this.push(`    type: ${this.aliasedType},`);
+    this.push(`    itemType: ${this.itemType},`, this.array);
+    this.push("    required: true,", this.required);
+    this.push("    default: [],", this.default);
+    this.push("  },");
+
+    return this.contents;
+  }
+
+  push(value, condition = true) {
+    if (condition) this.contents.push(value);
+  }
+}

--- a/battlecry/generators/schema/schema.generator.js
+++ b/battlecry/generators/schema/schema.generator.js
@@ -1,0 +1,45 @@
+import { Generator, File } from 'battlecry';
+import Attribute from './Attribute';
+
+const DIST = 'src/domain/__na-me__'
+
+export default class SchemaGenerator extends Generator {
+  config = {
+    generate: {
+      args: 'name ...props?',
+      description: 'Create or modify schema adding attributes and methods'
+    }
+  };
+
+  get props() {
+    const props = this.args.props.length ? this.args.props : ['name'];
+    return props.reverse();
+  }
+
+  generate() {
+    const template = this.template();
+    let file = new File(`${DIST}/${template.filename}`, this.args.name);
+    if(!file.exists) file = template;
+
+    this.props.forEach(prop => {
+      if(prop.startsWith(':')) this.addMethod(file, prop)
+      else this.addAttribute(file, prop);
+    });
+
+    file.saveAs(`${DIST}/${template.filename}`, this.args.name);
+  }
+
+  addAttribute(file, name) {
+    const attribute = new Attribute(name);
+    file.after('attributes({', attribute.text, attribute.name);
+  }
+
+  addMethod(file, name) {
+    file.after('class ', [
+      '  __naMe__() {',
+      '    // Do something here',
+      '  }',
+      ''
+    ], name.substring(1));
+  }
+}

--- a/battlecry/generators/schema/templates/__NaMe__.js
+++ b/battlecry/generators/schema/templates/__NaMe__.js
@@ -1,0 +1,7 @@
+const { attributes } = require('structure');
+
+const __NaMe__ = attributes({
+})(class __NaMe__ {
+});
+
+module.exports = __NaMe__;


### PR DESCRIPTION
I added [BattleCry](https://github.com/pedsmoreira/battlecry) generators to help creating/updating schemas.

Those who have different setups can easily make use of this generators by editing the `schema.generator.js` file and/or the templates (they get downloaded via `cry download`).

## Example

```sh
cry g schema user name age:int:required cars:string[] favoriteBook:book friends:user[]:default :updateAge
```

![screen shot 2018-06-06 at 21 02 44](https://user-images.githubusercontent.com/5206633/41071201-ff2e0fca-69cc-11e8-9746-2f5ddf0a86f2.png)

Ideas on how these templates can be improved are very welcome.

## Notes

I wasn't sure where to add the description of how to use the generators, so I added them to the main README.md.