### PR TITLE
bugfix: don't change the object passed in the constructor

### DIFF
--- a/src/attributes/decorator.js
+++ b/src/attributes/decorator.js
@@ -20,7 +20,7 @@ function attributesDecorator(schema, schemaOptions = {}) {
     const WrapperClass = new Proxy(Class, {
       construct(target, constructorArgs, newTarget) {
         const instance = Reflect.construct(target, constructorArgs, newTarget);
-        const passedAttributes = constructorArgs[0] || {};
+        const passedAttributes = Object.assign({}, constructorArgs[0]);
 
         Initializer.initialize(passedAttributes, schema, instance);
 

--- a/test/unit/instanceAndUpdate.spec.js
+++ b/test/unit/instanceAndUpdate.spec.js
@@ -42,6 +42,14 @@ describe('instantiating a structure', () => {
     expect(user.name).to.equal('Me');
   });
 
+  it('don\'t reflect the changes outside of the escope', () => {
+    const rawUser = {};
+
+    new User(rawUser);
+
+    expect(rawUser).to.be.empty;
+  });
+
   it('ignores invalid attributes passed to constructor', () => {
     const user = new User({
       name: 'Myself',


### PR DESCRIPTION
Now, the structure never change any data outside the library escope.