### PR TITLE
Update to use new GitBook

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./docs/
+
+structure:
+  readme: ../README.md
+  summary: ../SUMMARY.md


### PR DESCRIPTION
GitBook has a new version, we should update it so we don't keep using the legacy.

https://docs.gitbook.com/integrations/github/content-configuration