### PR TITLE
Add contract to generic coercion

### DIFF
--- a/dist/structure.js
+++ b/dist/structure.js
@@ -747,31 +747,29 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	function getCoercion(typeDescriptor) {
-	  return types.find(function (c) {
+	  var coercion = types.find(function (c) {
 	    return c.type === typeDescriptor.type;
 	  });
+
+	  if (coercion) {
+	    return coercion;
+	  }
+
+	  return genericCoercionFor;
 	}
 
 	function createCoercionFunction(coercion, typeDescriptor) {
-	  if (!coercion) {
-	    return genericCoercionFor(typeDescriptor);
-	  }
-
 	  return function coerce(value) {
 	    if (value === undefined) {
 	      return;
 	    }
 
-	    if (needsCoercion(value, coercion)) {
-	      return coercion.coerce(value);
+	    if (!coercion.isCoerced(value, typeDescriptor)) {
+	      return coercion.coerce(value, typeDescriptor);
 	    }
 
 	    return value;
 	  };
-	}
-
-	function needsCoercion(value, coercion) {
-	  return !coercion.test(value);
 	}
 
 /***/ },
@@ -858,25 +856,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var getType = __webpack_require__(22);
 
-	module.exports = function genericCoercionFor(typeDescriptor) {
-	  return function coerce(value) {
-	    if (value === undefined) {
-	      return;
-	    }
-
+	module.exports = {
+	  isCoerced: function isCoerced(value, typeDescriptor) {
+	    return value instanceof getType(typeDescriptor);
+	  },
+	  coerce: function coerce(value, typeDescriptor) {
 	    var type = getType(typeDescriptor);
 
-	    if (!needsCoercion(value, type)) {
-	      return value;
-	    }
-
 	    return new type(value);
-	  };
+	  }
 	};
-
-	function needsCoercion(value, type) {
-	  return !(value instanceof type);
-	}
 
 /***/ },
 /* 24 */
@@ -889,7 +878,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = {
 	  type: String,
-	  test: isString,
+	  isCoerced: isString,
 	  coerce: function coerce(value) {
 	    if (value === null) {
 	      return '';
@@ -910,7 +899,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = {
 	  type: Number,
-	  test: isNumber,
+	  isCoerced: isNumber,
 	  coerce: function coerce(value) {
 	    if (value === null) {
 	      return 0;
@@ -931,7 +920,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = {
 	  type: Boolean,
-	  test: isBoolean,
+	  isCoerced: isBoolean,
 	  coerce: function coerce(value) {
 	    return Boolean(value);
 	  }

--- a/src/coercion/boolean.js
+++ b/src/coercion/boolean.js
@@ -2,7 +2,7 @@ const { isBoolean } = require('lodash');
 
 module.exports = {
   type: Boolean,
-  test: isBoolean,
+  isCoerced: isBoolean,
   coerce(value) {
     return Boolean(value);
   }

--- a/src/coercion/boolean.js
+++ b/src/coercion/boolean.js
@@ -3,7 +3,8 @@ const { isBoolean } = require('lodash');
 module.exports = {
   type: Boolean,
   isCoerced: isBoolean,
+  default: false,
   coerce(value) {
-    return Boolean(value);
+    return this.type(value);
   }
 };

--- a/src/coercion/coercion.js
+++ b/src/coercion/coercion.js
@@ -7,9 +7,7 @@ exports.execute = curryRight(
     }
 
     if (value === null) {
-      return isFunction(coercion.default)
-        ? coercion.default()
-        : coercion.default;
+      return getDefaultValue(coercion);
     }
 
     if (coercion.isCoerced(value, typeDescriptor)) {
@@ -19,3 +17,7 @@ exports.execute = curryRight(
     return coercion.coerce(value, typeDescriptor);
   }
 );
+
+function getDefaultValue(coercion) {
+  return isFunction(coercion.default) ? coercion.default() : coercion.default;
+}

--- a/src/coercion/coercion.js
+++ b/src/coercion/coercion.js
@@ -1,0 +1,19 @@
+const { curryRight } = require('lodash');
+
+exports.execute = curryRight(
+  function(value, coercion, typeDescriptor) {
+    if(value === undefined) {
+      return;
+    }
+
+    if (value === null) {
+      return coercion.default;
+    }
+
+    if (coercion.isCoerced(value, typeDescriptor)) {
+      return value;
+    }
+
+    return coercion.coerce(value, typeDescriptor);
+  }
+);

--- a/src/coercion/coercion.js
+++ b/src/coercion/coercion.js
@@ -1,4 +1,4 @@
-const { curryRight } = require('lodash');
+const { isFunction, curryRight } = require('lodash');
 
 exports.execute = curryRight(
   function(value, coercion, typeDescriptor) {
@@ -7,7 +7,9 @@ exports.execute = curryRight(
     }
 
     if (value === null) {
-      return coercion.default;
+      return isFunction(coercion.default)
+        ? coercion.default()
+        : coercion.default;
     }
 
     if (coercion.isCoerced(value, typeDescriptor)) {

--- a/src/coercion/date.js
+++ b/src/coercion/date.js
@@ -3,7 +3,7 @@ const { isDate } = require('lodash');
 module.exports = {
   type: Date,
   isCoerced: isDate,
-  default: new Date(null),
+  default: () => new Date(null),
   coerce(value) {
     return new this.type(value);
   }

--- a/src/coercion/date.js
+++ b/src/coercion/date.js
@@ -1,0 +1,10 @@
+const { isDate } = require('lodash');
+
+module.exports = {
+  type: Date,
+  isCoerced: isDate,
+  default: new Date(null),
+  coerce(value) {
+    return new this.type(value);
+  }
+};

--- a/src/coercion/generic.js
+++ b/src/coercion/generic.js
@@ -1,21 +1,12 @@
 const getType = require('../typeResolver');
 
-module.exports = function genericCoercionFor(typeDescriptor) {
-  return function coerce(value) {
-    if(value === undefined) {
-      return;
-    }
-
+module.exports = {
+  isCoerced: function(value, typeDescriptor) {
+    return value instanceof getType(typeDescriptor);
+  },
+  coerce(value, typeDescriptor) {
     const type = getType(typeDescriptor);
 
-    if(!needsCoercion(value, type)) {
-      return value;
-    }
-
     return new type(value);
-  };
+  }
 };
-
-function needsCoercion(value, type) {
-  return !(value instanceof type);
-}

--- a/src/coercion/generic.js
+++ b/src/coercion/generic.js
@@ -1,7 +1,7 @@
 const getType = require('../typeResolver');
 
 module.exports = {
-  isCoerced: function(value, typeDescriptor) {
+  isCoerced(value, typeDescriptor) {
     return value instanceof getType(typeDescriptor);
   },
   coerce(value, typeDescriptor) {

--- a/src/coercion/index.js
+++ b/src/coercion/index.js
@@ -18,27 +18,25 @@ exports.for = function coercionFor(typeDescriptor, itemTypeDescriptor) {
 };
 
 function getCoercion(typeDescriptor) {
-  return types.find((c) => c.type === typeDescriptor.type);
+  const coercion = types.find((c) => c.type === typeDescriptor.type);
+
+  if(coercion) {
+    return coercion;
+  }
+
+  return genericCoercionFor;
 }
 
 function createCoercionFunction(coercion, typeDescriptor) {
-  if(!coercion) {
-    return genericCoercionFor(typeDescriptor);
-  }
-
   return function coerce(value) {
     if(value === undefined) {
       return;
     }
 
-    if(needsCoercion(value, coercion)) {
-      return coercion.coerce(value);
+    if(!coercion.isCoerced(value, typeDescriptor)) {
+      return coercion.coerce(value, typeDescriptor);
     }
 
     return value;
   };
-}
-
-function needsCoercion(value, coercion) {
-  return !coercion.test(value);
 }

--- a/src/coercion/index.js
+++ b/src/coercion/index.js
@@ -1,10 +1,12 @@
 const arrayCoercionFor = require('./array');
 const genericCoercionFor = require('./generic');
+const Coercion = require('./coercion');
 
 const types = [
   require('./string'),
   require('./number'),
-  require('./boolean')
+  require('./boolean'),
+  require('./date')
 ];
 
 exports.for = function coercionFor(typeDescriptor, itemTypeDescriptor) {
@@ -14,7 +16,7 @@ exports.for = function coercionFor(typeDescriptor, itemTypeDescriptor) {
 
   const coercion = getCoercion(typeDescriptor);
 
-  return createCoercionFunction(coercion, typeDescriptor);
+  return Coercion.execute(coercion, typeDescriptor);
 };
 
 function getCoercion(typeDescriptor) {
@@ -25,18 +27,4 @@ function getCoercion(typeDescriptor) {
   }
 
   return genericCoercionFor;
-}
-
-function createCoercionFunction(coercion, typeDescriptor) {
-  return function coerce(value) {
-    if(value === undefined) {
-      return;
-    }
-
-    if(!coercion.isCoerced(value, typeDescriptor)) {
-      return coercion.coerce(value, typeDescriptor);
-    }
-
-    return value;
-  };
 }

--- a/src/coercion/number.js
+++ b/src/coercion/number.js
@@ -2,7 +2,7 @@ const { isNumber } = require('lodash');
 
 module.exports = {
   type: Number,
-  test: isNumber,
+  isCoerced: isNumber,
   coerce(value) {
     if(value === null) {
       return 0;

--- a/src/coercion/number.js
+++ b/src/coercion/number.js
@@ -3,11 +3,8 @@ const { isNumber } = require('lodash');
 module.exports = {
   type: Number,
   isCoerced: isNumber,
+  default: 0,
   coerce(value) {
-    if(value === null) {
-      return 0;
-    }
-
-    return Number(value);
+    return this.type(value);
   }
 };

--- a/src/coercion/string.js
+++ b/src/coercion/string.js
@@ -2,7 +2,7 @@ const { isString } = require('lodash');
 
 module.exports = {
   type: String,
-  test: isString,
+  isCoerced: isString,
   coerce(value) {
     if(value === null) {
       return '';

--- a/src/coercion/string.js
+++ b/src/coercion/string.js
@@ -3,11 +3,8 @@ const { isString } = require('lodash');
 module.exports = {
   type: String,
   isCoerced: isString,
+  default: '',
   coerce(value) {
-    if(value === null) {
-      return '';
-    }
-
-    return String(value);
+    return this.type(value);
   }
 };

--- a/test/unit/coercion/coercion.spec.js
+++ b/test/unit/coercion/coercion.spec.js
@@ -1,0 +1,76 @@
+const { expect } = require('chai');
+const { spy } = require('sinon');
+const Coercion = require('../../../src/coercion/coercion');
+const CoercionNumber = require('../../../src/coercion/number');
+
+describe('Coercion', () => {
+  describe('.execute', () => {
+    let value, coercion, typeDescriptor;
+
+    context('when value is undefined', () => {
+      beforeEach(() => {
+        value = undefined;
+        coercion = null;
+        typeDescriptor = null;
+      });
+
+      it('returns undefined', () => {
+        const executionResponse = Coercion.execute(value, coercion, typeDescriptor);
+
+        expect(executionResponse).to.be.undefined;
+      });
+    });
+
+    context('when value is null', () => {
+      beforeEach(() => {
+        value = null;
+        coercion = CoercionNumber;
+        typeDescriptor = null;
+      });
+
+      it('returns default value present on Coercion object', () => {
+        const executionResponse = Coercion.execute(value, coercion, typeDescriptor);
+
+        expect(executionResponse).to.be.eq(0);
+      });
+    });
+
+    context('when value is already coerced to correct type', () => {
+      beforeEach(() => {
+        value = 42;
+        coercion = CoercionNumber;
+        typeDescriptor = null;
+
+        spy(CoercionNumber, 'coerce');
+      });
+
+      afterEach(() => CoercionNumber.coerce.restore());
+
+      it('returns default value present on Coercion object', () => {
+        const executionResponse = Coercion.execute(value, coercion, typeDescriptor);
+
+        expect(executionResponse).to.be.eq(42);
+      });
+
+      it('does not invoke #coerce function', () => {
+        Coercion.execute(value, coercion, typeDescriptor);
+
+        expect(coercion.coerce.called).to.be.false;
+      });
+    });
+
+    context('when value is not coerced to correct type', () => {
+      beforeEach(() => {
+        value = '1008';
+        coercion = CoercionNumber;
+        typeDescriptor = null;
+      });
+
+      it('returns default value present on Coercion object', () => {
+        const executionResponse = Coercion.execute(value, coercion, typeDescriptor);
+
+        expect(executionResponse).to.be.eq(1008);
+      });
+    });
+  });
+});

--- a/test/unit/coercion/coercion.spec.js
+++ b/test/unit/coercion/coercion.spec.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const { spy } = require('sinon');
 const Coercion = require('../../../src/coercion/coercion');
 const CoercionNumber = require('../../../src/coercion/number');
+const CoercionDate = require('../../../src/coercion/date');
 
 describe('Coercion', () => {
   describe('.execute', () => {
@@ -22,16 +23,38 @@ describe('Coercion', () => {
     });
 
     context('when value is null', () => {
-      beforeEach(() => {
-        value = null;
-        coercion = CoercionNumber;
-        typeDescriptor = null;
+      context('and default attribute is a plain value', () => {
+        beforeEach(() => {
+          value = null;
+          coercion = CoercionNumber;
+          typeDescriptor = null;
+        });
+
+        it('returns default value present on Coercion object', () => {
+          const executionResponse = Coercion.execute(value, coercion, typeDescriptor);
+
+          expect(executionResponse).to.be.eq(0);
+        });
       });
 
-      it('returns default value present on Coercion object', () => {
-        const executionResponse = Coercion.execute(value, coercion, typeDescriptor);
+      context('and default attribute is a dynamic value', () => {
+        beforeEach(() => {
+          value = null;
+          coercion = CoercionDate;
+          typeDescriptor = null;
+        });
 
-        expect(executionResponse).to.be.eq(0);
+        it('returns default value present on Coercion object', () => {
+          const executionResponse = Coercion.execute(value, coercion, typeDescriptor);
+
+          expect(executionResponse).to.be.eql(new Date('1970-01-01T00:00:00Z'));
+        });
+
+        it('creates a new object instance for default value', () => {
+          const executionResponse = Coercion.execute(value, coercion, typeDescriptor);
+
+          expect(executionResponse).not.to.be.eq(coercion.default());
+        });
       });
     });
 


### PR DESCRIPTION
In face of PR #67 I'm proposing a change on `coercion/generic.js` to turn this module an implementation of a common contract based on other `coercion/*` files.