### PR TITLE
Allow defaulting when null and not nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-alpha
+Breaking changes:
+
+* Non-nullable attributes with value null will use default value
+
 ## 1.8.0 - 2019-09-16
 Enhancements:
 * Add `unique` validation to arrays

--- a/docs/schema-concept/nullable-attributes.md
+++ b/docs/schema-concept/nullable-attributes.md
@@ -1,8 +1,37 @@
 # Nullable attributes
 
-You can change the way an attribute is treated when the value `null` is assigned to it by using the `nullable` option with the value `true`, this would affect the way the attribute is coerced, validated and serialized.
+You can change the way an attribute is treated when the value `null` is assigned to it by using the `nullable` option with the value `true`, this would affect the way the attribute is defaulted, coerced, validated and serialized.
 
-If you do not set the `nullable` option for an attribute it will default to `false` and make your attribute **not nullable**.
+If you do not set the `nullable` option it will default to `false` and automatically make your attribute **non-nullable**.
+
+## Nullability and `default` option
+
+Non-nullable attributes with the value `null` will fallback to the value set as default the same way `undefined` does. But if the attribute is nullable, it will **only** fallback to the default if its value is `undefined`.
+
+```javascript
+const User = attributes({
+  name: {
+    // automatically non-nullable
+    type: String,
+    default: 'Some string',
+  },
+  nickname: {
+    type: String,
+    nullable: false,
+    default: 'Some other string',
+  },
+})(class User {});
+
+const userA = new User({ name: null, nickname: null });
+userA.attributes; // { name: 'Some string', nickname: null }
+
+const userB = new User({ name: null, nickname: undefined });
+userB.attributes; // { name: 'Some string', nickname: 'Some other string' }
+```
+
+## Coercion
+
+Non-nullable values will fallback to their null-equivalent values. More details about it can be found at the [coercion](coercion/README.md) section. Nullable attributes will remain `null` as described in the section above.
 
 ```javascript
 /*
@@ -11,21 +40,28 @@ If you do not set the `nullable` option for an attribute it will default to `fal
 const User = attributes({
   name: {
     type: String,
+    nullable: true,
+  },
+  nickname: {
+    // automatically non-nullable
+    type: String,
     empty: true,
   },
-  age: Number,
-  active: Boolean,
-  createdAt: Date,
+  age: Number, // << automatically non-nullable
+  active: Boolean, // << automatically non-nullable
+  createdAt: Date, // << automatically non-nullable
 })(class User {});
 
 const user = new User({
   name: null,
+  nickname: null,
   age: null,
   active: null,
   createdAt: null,
 });
 
-user.attributes; // { name: '', age: 0, active: false, createdAt: 1970-01-01T00:00:00.000Z }
+// Only non-nullable values are coerced to their null-equivalent values
+user.attributes; // { name: null, nickname: '', age: 0, active: false, createdAt: 1970-01-01T00:00:00.000Z }
 user.validate(); // { valid: true }
 ```
 
@@ -98,8 +134,26 @@ user.attributes; // { name: null }
 user.validate(); // { valid: true }
 ```
 
+## Nullability and serialization
+
+Usually an attribute with the value **undefined** or **null** is not included when you serialize your structure. But when it is **nullable** and its value is `null`, this attribute is going to be returned in your serialized schema.
+
+```javascript
+const User = attributes({
+  name: {
+    type: String,
+    nullable: false,
+  },
+  nickname: {
+    type: String,
+    nullable: true,
+  },
+})(class User {});
+
+const user = new User({ name: undefined, nickname: null });
+user.toJSON(); // { nickname: null }
+```
+
 **Important:**
 
 - Notice that by not using the `nullable` option the **default** value for **String** is an empty string, which means that you need to accept empty strings to make your schema valid.
-
-- Notice that usually an attribute with the value **undefined** or **null** is not included when you serialize your structure, but when it is **nullable** this attribute is going to be returned in your serialized schema.

--- a/docs/schema-concept/nullable-attributes.md
+++ b/docs/schema-concept/nullable-attributes.md
@@ -2,104 +2,104 @@
 
 You can change the way an attribute is treated when the value `null` is assigned to it by using the `nullable` option with the value `true`, this would affect the way the attribute is coerced, validated and serialized.
 
-If you do not set the `nullable` option for an attribute it will default to `false` and make your attribute __not nullable__.
+If you do not set the `nullable` option for an attribute it will default to `false` and make your attribute **not nullable**.
 
 ```javascript
 /*
  * User.js
-*/
+ */
 const User = attributes({
   name: {
     type: String,
-    empty: true
+    empty: true,
   },
   age: Number,
   active: Boolean,
-  createdAt: Date
-})(class User { });
+  createdAt: Date,
+})(class User {});
 
 const user = new User({
   name: null,
   age: null,
   active: null,
-  createdAt: null
+  createdAt: null,
 });
 
 user.attributes; // { name: '', age: 0, active: false, createdAt: 1970-01-01T00:00:00.000Z }
-user.validate() // { valid: true }
+user.validate(); // { valid: true }
 ```
 
 ### Nullable optional attributes
 
-When you set an optional attribute to be __nullable__ you are choosing not to assign a default value for it when instantiating your structure passing `null` as the value of this attribute, so the actual value will be `null` and will be considered valid.
+When you set an optional attribute to be **nullable** you are choosing not to assign a default value for it when instantiating your structure passing `null` as the value of this attribute, so the actual value will be `null` and will be considered valid.
 
 ```javascript
 /*
  * User.js
-*/
+ */
 const User = attributes({
   name: {
     type: String,
-    nullable: true
-  }
-})(class User { });
+    nullable: true,
+  },
+})(class User {});
 
 const user = new User({
-  name: null
+  name: null,
 });
 
 user.attributes; // { name: null }
-user.validate() // { valid: true }
+user.validate(); // { valid: true }
 ```
 
 ### Nullable required attributes
 
-We consider that when an attribute is __required__ there should be some value assigned to it even if it's `undefined`, `null` or any other value. It means that coercion will never assign a __default__ value to __required__ attributes even if __nullable__ option is __false__.
+We consider that when an attribute is **required** there should be some value assigned to it even if it's `undefined`, `null` or any other value. It means that coercion will never assign a **default** value to **required** attributes even if **nullable** option is **false**.
 
 ```javascript
 /*
  * User.js
-*/
+ */
 const User = attributes({
   name: {
     type: String,
     required: true,
-    nullable: false // non-nullable required attribute
-  }
-})(class User { });
+    nullable: false, // non-nullable required attribute
+  },
+})(class User {});
 
 const user = new User({
-  name: null
+  name: null,
 });
 
 user.attributes; // { name: null }
-user.validate() // { valid: false }
+user.validate(); // { valid: false }
 ```
 
-But notice that you can choose to allow __null__ values on __required__ attributes which will cause the validation to return __true__.
+But notice that you can choose to allow **null** values on **required** attributes which will cause the validation to return **true**.
 
 ```javascript
 /*
  * User.js
-*/
+ */
 const User = attributes({
   name: {
     type: String,
     required: true,
-    nullable: true
-  }
-})(class User { });
+    nullable: true,
+  },
+})(class User {});
 
 const user = new User({
-  name: null
+  name: null,
 });
 
 user.attributes; // { name: null }
-user.validate() // { valid: true }
+user.validate(); // { valid: true }
 ```
 
 **Important:**
 
-- Notice that by not using the `nullable` option the __default__ value for __String__ is an empty string, which means that you need to accept empty strings to make your schema valid.
+- Notice that by not using the `nullable` option the **default** value for **String** is an empty string, which means that you need to accept empty strings to make your schema valid.
 
-- Notice that usually an attribute with the value __undefined__ or __null__ is not included when you serialize your structure, but when it is __nullable__ this attribute is going to be returned in your serialized schema.
+- Notice that usually an attribute with the value **undefined** or **null** is not included when you serialize your structure, but when it is **nullable** this attribute is going to be returned in your serialized schema.

--- a/packages/structure/src/initialization/index.js
+++ b/packages/structure/src/initialization/index.js
@@ -13,18 +13,10 @@ exports.for = function initializationForSchema(schema) {
         const attrPassedValue = attributes[attrDefinition.name];
 
         // will coerce through setters
-        instance[attrDefinition.name] = initializedValue(instance, attrPassedValue, attrDefinition);
+        instance[attrDefinition.name] = attrDefinition.initialize(instance, attrPassedValue);
       }
 
       return instance;
     },
   };
-};
-
-const initializedValue = (instance, attrPassedValue, attrDefinition) => {
-  if (attrPassedValue !== undefined) {
-    return attrPassedValue;
-  }
-
-  return attrDefinition.initialize(instance);
 };

--- a/packages/structure/src/schema/AttributeDefinitions/AttributeDefinition.js
+++ b/packages/structure/src/schema/AttributeDefinitions/AttributeDefinition.js
@@ -27,11 +27,11 @@ class AttributeDefinition {
   }
 
   static compare(definitionA, definitionB) {
-    if (definitionA.hasDynamicDefault === definitionB.hasDynamicDefault) {
+    if (definitionA.isDynamicDefault === definitionB.isDynamicDefault) {
       return 0;
     }
 
-    if (definitionA.hasDynamicDefault) {
+    if (definitionA.isDynamicDefault) {
       return 1;
     }
 
@@ -62,7 +62,8 @@ class AttributeDefinition {
 
     this.name = name;
     this.options = options;
-    this.hasDynamicDefault = isFunction(options.default);
+    this.hasDefault = 'default' in options;
+    this.isDynamicDefault = isFunction(options.default);
     this.hasDynamicType = hasDynamicType(options);
     this.schema = schema;
 
@@ -116,7 +117,7 @@ class AttributeDefinition {
   }
 
   defaultValueFor(instance) {
-    if (this.hasDynamicDefault) {
+    if (this.isDynamicDefault) {
       return this.options.default(instance);
     }
 
@@ -124,11 +125,10 @@ class AttributeDefinition {
   }
 
   shouldInitializeToDefault(attributeValue) {
-    const hasDefault = 'default' in this.options;
     const isUndefined = attributeValue === undefined;
     const isDefaultableNull = !this.options.nullable && attributeValue === null;
 
-    return hasDefault && (isUndefined || isDefaultableNull);
+    return this.hasDefault && (isUndefined || isDefaultableNull);
   }
 }
 

--- a/packages/structure/src/schema/AttributeDefinitions/AttributeDefinition.js
+++ b/packages/structure/src/schema/AttributeDefinitions/AttributeDefinition.js
@@ -27,11 +27,11 @@ class AttributeDefinition {
   }
 
   static compare(definitionA, definitionB) {
-    if (definitionA.dynamicDefault === definitionB.dynamicDefault) {
+    if (definitionA.hasDynamicDefault === definitionB.hasDynamicDefault) {
       return 0;
     }
 
-    if (definitionA.dynamicDefault) {
+    if (definitionA.hasDynamicDefault) {
       return 1;
     }
 
@@ -62,19 +62,13 @@ class AttributeDefinition {
 
     this.name = name;
     this.options = options;
-    this.dynamicDefault = isFunction(options.default);
+    this.hasDynamicDefault = isFunction(options.default);
     this.hasDynamicType = hasDynamicType(options);
     this.schema = schema;
 
     if (options.itemType) {
       this.isArrayType = true;
       this.itemTypeDefinition = AttributeDefinition.for('item', options.itemType, schema);
-    }
-
-    if (this.dynamicDefault) {
-      this.initialize = options.default;
-    } else {
-      this.initialize = () => options.default;
     }
 
     this.coercion = Coercion.for(this);
@@ -111,6 +105,30 @@ class AttributeDefinition {
 
   isValueNullable(attributeValue) {
     return attributeValue !== undefined && this.options.nullable;
+  }
+
+  initialize(instance, attributeValue) {
+    if (this.shouldInitializeToDefault(attributeValue)) {
+      return this.defaultValueFor(instance);
+    }
+
+    return attributeValue;
+  }
+
+  defaultValueFor(instance) {
+    if (this.hasDynamicDefault) {
+      return this.options.default(instance);
+    }
+
+    return this.options.default;
+  }
+
+  shouldInitializeToDefault(attributeValue) {
+    const hasDefault = 'default' in this.options;
+    const isUndefined = attributeValue === undefined;
+    const isDefaultableNull = !this.options.nullable && attributeValue === null;
+
+    return hasDefault && (isUndefined || isDefaultableNull);
   }
 }
 

--- a/packages/structure/test/unit/instanceAndUpdate.spec.js
+++ b/packages/structure/test/unit/instanceAndUpdate.spec.js
@@ -130,7 +130,7 @@ describe('instantiating a structure', () => {
         });
 
         describe('when passed value is null', () => {
-          it('calls the function using the instance of the object as parameter and perform coercionl', () => {
+          it('calls the function using the instance of the object as parameter and perform coercion', () => {
             const user = new User({ uuid: null });
 
             expect(user.uuid).toEqual('10');

--- a/packages/structure/test/unit/instanceAndUpdate.spec.js
+++ b/packages/structure/test/unit/instanceAndUpdate.spec.js
@@ -25,6 +25,15 @@ describe('instantiating a structure', () => {
         type: String,
         default: (instance) => instance.someMethod(),
       },
+      nullableWithoutDefault: {
+        type: String,
+        nullable: true,
+      },
+      nullableWithDefault: {
+        type: String,
+        default: 'The Default',
+        nullable: true,
+      },
     })(
       class User {
         constructor() {
@@ -93,19 +102,39 @@ describe('instantiating a structure', () => {
 
   describe('attributes initialization', () => {
     describe('default value', () => {
-      describe('when attribute default value is a static value', () => {
-        it('defaults to the static value', () => {
-          const user = new User();
+      describe('when attribute is non-nullable and has static default', () => {
+        describe('when passed value is undefined', () => {
+          it('defaults to the static value', () => {
+            const user = new User();
 
-          expect(user.name).toEqual('Name');
+            expect(user.name).toEqual('Name');
+          });
+        });
+
+        describe('when passed value is null', () => {
+          it('defaults to the static value', () => {
+            const user = new User({ name: null });
+
+            expect(user.name).toEqual('Name');
+          });
         });
       });
 
-      describe('when attribute default value is a function', () => {
-        it('calls the function using the instance of the object as parameter and perform coercion', () => {
-          const user = new User();
+      describe('when attribute is non-nullable and default value is a function', () => {
+        describe('when passed value is undefined', () => {
+          it('calls the function using the instance of the object as parameter and perform coercion', () => {
+            const user = new User();
 
-          expect(user.uuid).toEqual('10');
+            expect(user.uuid).toEqual('10');
+          });
+        });
+
+        describe('when passed value is null', () => {
+          it('calls the function using the instance of the object as parameter and perform coercionl', () => {
+            const user = new User({ uuid: null });
+
+            expect(user.uuid).toEqual('10');
+          });
         });
       });
 
@@ -131,6 +160,42 @@ describe('instantiating a structure', () => {
             const user = new User();
 
             expect(user.attrUsingMethodUsingAttr).toEqual('Method => Name');
+          });
+        });
+      });
+
+      describe('when attribute is nullable and has a default', () => {
+        describe('when passed value is undefined', () => {
+          it('uses default', () => {
+            const user = new User({});
+
+            expect(user.nullableWithDefault).toEqual('The Default');
+          });
+        });
+
+        describe('when passed value is null', () => {
+          it('leaves it as null', () => {
+            const user = new User({ nullableWithDefault: null });
+
+            expect(user.nullableWithDefault).toBeNull();
+          });
+        });
+      });
+
+      describe('when attribute is nullable and has no default', () => {
+        describe('when passed value is undefined', () => {
+          it('leaves it as undefined', () => {
+            const user = new User({});
+
+            expect(user.nullableWithoutDefault).toEqual(undefined);
+          });
+        });
+
+        describe('when passed value is null', () => {
+          it('leaves it as null', () => {
+            const user = new User({ nullableWithoutDefault: null });
+
+            expect(user.nullableWithoutDefault).toBeNull();
           });
         });
       });


### PR DESCRIPTION
In Structure v2 we'll allow nullable attributes with the value `null` to use the `default` value the same way `undefined` does.