### PR TITLE
Allow to pass custom identifier for dynamic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Breaking changes:
 - Joi is updated to v16
   - Attribute path in validation _errors_ is an array instead of a string
   - Attribute path in validation _messages_ contains the whole path joined by '.'
-- It's required that the name used for dynamic imports be always the same as the name of the type
+- It's required that the name used for dynamic imports be always the same as the name of the type or to use custom identifiers
 - Non-nullable attributes with value null will use default value
 
 ## 1.8.0 - 2019-09-16

--- a/docs/schema-concept/circular-references-and-dynamic-types.md
+++ b/docs/schema-concept/circular-references-and-dynamic-types.md
@@ -2,48 +2,124 @@
 
 Sometimes we may need to have a type reference itself in its attributes, or have two types that reference eachother in separate files, it can be a complication because it's not possible to do this using the type definitions like we did before. For cases like this we can use a feature called "dynamic types".
 
-When using dynamic types you can pass a string instead of the type itself in the type definition, and pass an object as the _second_ parameter of the `attributes` function with an object with a key called `dynamics`. This key will have functions named after the dynamic attribute types, that will be called when the given type is used, like this:
-
+When using dynamic types you can pass a string instead of the type itself in the type definition, this string will contain the type **identifier**, and then pass an object as the _second_ parameter of the `attributes` function with a key `dynamics` where the concrete type for each identifier is declared:
 
 ```javascript
 /*
  * User.js
-*/
-const User = attributes({
-  name: String,
-  friends: {
-    type: Array,
-    itemType: 'User' // << dynamic type name
+ */
+const User = attributes(
+  {
+    name: String,
+    friends: {
+      type: Array,
+      itemType: 'User', // << dynamic type with inferred identifier
+    },
+    favoriteBook: {
+      type: 'BookStructure', // << dynamic type with custom identifier
+      required: true,
+    },
+    books: {
+      type: 'BooksCollection', // << dynamic type with inferred identifier
+      itemType: String,
+    },
   },
-  favoriteBook: {
-    type: 'Book', // << dynamic type name
-    required: true
-  },
-  books: {
-    type: 'BooksCollection', // << dynamic type name
-    itemType: String
+  {
+    dynamics: {
+      /* dynamic types */
+      User: () => User,
+      BookStructure: () => require('./Book'),
+      BooksCollection: () => require('./BooksCollection'),
+    },
   }
-}, {
-  dynamics: { // << dynamic types values
-    User: () => User,
-    Book: () => require('./Book'),
-    BooksCollection: () => require('./BooksCollection')
-  }
-})(class User { });
+)(class User {});
 
 /*
  * Book.js
-*/
-const Book = attributes({
-  name: String,
-  owner: 'User', // << dynamic type name
-  nextBook: 'Book' // << dynamic type name
-}, {
-  dynamics: { // << dynamic types values
-    User: () => require('./User'),
-    Book: () => Book
+ */
+const Book = attributes(
+  {
+    name: String,
+    owner: 'User', // << dynamic type with inferred identifier
+    nextBook: 'BookStructure', // << dynamic type with custom identifier
+  },
+  {
+    identifier: 'BookStructure', // << custom identifier
+    dynamics: {
+      /* dynamic types */
+      User: () => require('./User'),
+      BookStructure: () => Book,
+    },
   }
-})(class Book { });
+)(class Book {});
 ```
 
-Notice that the _name_ of the type has to be the same name of the key inside the `dynamics` object. Also, it's important that the require be done __inside__ the function when the dynamic type also references the current type (in the example above, the type `User` has an attribute of the type `Book`, and the type `Book` has an attribute of the type `User`).
+## Dynamic type identifier
+
+The identifier of the type has to be same everywhere it's used, and can be defined in two ways:
+
+### Inferred identifier
+
+The identifier can be inferred based in the class that is wrapped by the `attributes` function. In backend scenarios this will be the most common case:
+
+```js
+const User = attributes(
+  {
+    name: String,
+    bestFriend: 'User', // [A] type with inferred identifier
+  },
+  {
+    dynamics: {
+      User: () => User, // [B] inferred identifier concrete type
+    },
+  }
+)(
+  class User {
+    //   ^ the name of this class is the identifier
+    // so if we change this name to UserEntity, we'll have to change
+    // both [A] and [B] to use the string 'UserEntity' instead of 'User'
+  }
+);
+```
+
+### Custom identifier
+
+If for some reason you can't rely in the class name, be it because you're using a compiler that strip class names or create a dynamic one, you can explicitly set one.
+
+To do that, in the second argument of the `attributes` function (e.g. the options) you should add a `identifier` key and set it to be the string with the identifier of that type and then use that custom value everywhere this type is needed dynamically:
+
+```js
+const User = attributes(
+  {
+    name: String,
+    bestFriend: 'UserEntity', // << type with custom identifier
+  },
+  {
+    identifier: 'UserEntity', // << custom identifier
+    dynamics: {
+      UserEntity: () => User, // << custom identifier concrete type
+    },
+  }
+)(class User {});
+```
+
+### Concrete type definition inside `dynamics`
+
+It's important that the `require` has to be done **inside** the function when the dynamic type if a `require` is needed:
+
+```js
+const Book = attributes(
+  {
+    name: String,
+    owner: 'User',
+    nextBook: 'BookStructure',
+  },
+  {
+    identifier: 'BookStructure',
+    dynamics: {
+      User: () => require('./User'), // << like this
+      BookStructure: () => Book,
+    },
+  }
+)(class Book {});
+```

--- a/packages/structure/src/schema/index.js
+++ b/packages/structure/src/schema/index.js
@@ -51,7 +51,7 @@ class Schema {
     this.options = options;
     this.attributeDefinitions = AttributeDefinitions.for(attributeDefinitions, { schema: this });
     this.wrappedClass = wrappedClass;
-    this.identifier = wrappedClass.name;
+    this.identifier = options.identifier || wrappedClass.name;
 
     this.initialization = Initialization.for(this);
     this.validation = Validation.for(this);

--- a/packages/structure/test/fixtures/CircularBookCustomIdentifier.js
+++ b/packages/structure/test/fixtures/CircularBookCustomIdentifier.js
@@ -1,0 +1,21 @@
+const { attributes } = require('../../src');
+
+const Book = attributes(
+  {
+    name: String,
+    owner: 'UserEntity',
+    nextBook: 'BookEntity',
+    pages: {
+      type: Number,
+    },
+  },
+  {
+    identifier: 'BookEntity',
+    dynamics: {
+      UserEntity: () => require('./CircularUserCustomIdentifier'),
+      BookEntity: () => Book,
+    },
+  }
+)(class Book {});
+
+module.exports = Book;

--- a/packages/structure/test/fixtures/CircularUserCustomIdentifier.js
+++ b/packages/structure/test/fixtures/CircularUserCustomIdentifier.js
@@ -1,0 +1,25 @@
+const { attributes } = require('../../src');
+
+const User = attributes(
+  {
+    name: String,
+    friends: {
+      type: Array,
+      itemType: 'UserEntity',
+    },
+    favoriteBook: {
+      type: 'BookEntity',
+      required: true,
+      nullable: true,
+    },
+  },
+  {
+    identifier: 'UserEntity',
+    dynamics: {
+      UserEntity: () => User,
+      BookEntity: () => require('./CircularBookCustomIdentifier'),
+    },
+  }
+)(class User {});
+
+module.exports = User;

--- a/packages/structure/test/unit/creatingStructureClass.spec.js
+++ b/packages/structure/test/unit/creatingStructureClass.spec.js
@@ -125,15 +125,24 @@ describe('creating a structure class', () => {
   });
 
   describe('when using dynamic attribute types', () => {
-    it('allows to use dynamic values without breaking', () => {
+    it('allows to use dynamic values', () => {
       require('../fixtures/CircularUser');
       require('../fixtures/CircularBook');
     });
 
-    it('breaks if there is no value for dynamic type', () => {
-      expect(() => {
-        require('../fixtures/BrokenCircularBook');
-      }).toThrow('Missing dynamic type for attribute: owner');
+    describe('when using custom identifiers', () => {
+      it('allows to use dynamic types', () => {
+        require('../fixtures/CircularUserCustomIdentifier');
+        require('../fixtures/CircularBookCustomIdentifier');
+      });
+    });
+
+    describe('when some dynamic type is missing value', () => {
+      it('breaks', () => {
+        expect(() => {
+          require('../fixtures/BrokenCircularBook');
+        }).toThrow('Missing dynamic type for attribute: owner');
+      });
     });
   });
 });

--- a/packages/structure/test/unit/validation/nestedStructure.spec.js
+++ b/packages/structure/test/unit/validation/nestedStructure.spec.js
@@ -262,80 +262,162 @@ describe('validation', () => {
   });
 
   describe('Nested with structure class with dynamic attribute types', () => {
-    let CircularUser;
-    let CircularBook;
+    describe('when using inferred identifiers', () => {
+      let CircularUser;
+      let CircularBook;
 
-    beforeEach(() => {
-      CircularUser = require('../../fixtures/CircularUser');
-      CircularBook = require('../../fixtures/CircularBook');
+      beforeEach(() => {
+        CircularUser = require('../../fixtures/CircularUser');
+        CircularBook = require('../../fixtures/CircularBook');
+      });
+
+      describe('no validation', () => {
+        describe('when value is present', () => {
+          it('is valid', () => {
+            const user = new CircularUser({
+              friends: [],
+              favoriteBook: {},
+            });
+
+            expect(user).toBeValidStructure();
+          });
+        });
+
+        describe('when value is not present', () => {
+          it('is valid', () => {
+            const user = new CircularUser({
+              favoriteBook: {},
+            });
+
+            expect(user).toBeValidStructure();
+          });
+        });
+      });
+
+      describe('required', () => {
+        describe('when value is present', () => {
+          it('is valid', () => {
+            const user = new CircularUser({
+              favoriteBook: {},
+            });
+
+            expect(user).toBeValidStructure();
+          });
+        });
+
+        describe('when value is not present', () => {
+          it('is invalid', () => {
+            const user = new CircularUser();
+
+            expect(user).toHaveInvalidAttribute(['favoriteBook'], ['"favoriteBook" is required']);
+          });
+        });
+      });
+
+      describe('nested required', () => {
+        describe('when value is present', () => {
+          it('is valid', () => {
+            const book = new CircularBook({
+              owner: {
+                favoriteBook: new CircularBook(),
+              },
+            });
+
+            expect(book).toBeValidStructure();
+          });
+        });
+
+        describe('when value is not present', () => {
+          it('is invalid', () => {
+            const book = new CircularBook({
+              owner: new CircularUser(),
+            });
+
+            expect(book).toHaveInvalidAttribute(
+              ['owner', 'favoriteBook'],
+              ['"owner.favoriteBook" is required']
+            );
+          });
+        });
+      });
     });
 
-    describe('no validation', () => {
-      describe('when value is present', () => {
-        it('is valid', () => {
-          const user = new CircularUser({
-            friends: [],
-            favoriteBook: {},
-          });
+    describe('when using custom identifiers', () => {
+      let CircularUser;
+      let CircularBook;
 
-          expect(user).toBeValidStructure();
+      beforeEach(() => {
+        CircularUser = require('../../fixtures/CircularUserCustomIdentifier');
+        CircularBook = require('../../fixtures/CircularBookCustomIdentifier');
+      });
+
+      describe('no validation', () => {
+        describe('when value is present', () => {
+          it('is valid', () => {
+            const user = new CircularUser({
+              friends: [],
+              favoriteBook: {},
+            });
+
+            expect(user).toBeValidStructure();
+          });
+        });
+
+        describe('when value is not present', () => {
+          it('is valid', () => {
+            const user = new CircularUser({
+              favoriteBook: {},
+            });
+
+            expect(user).toBeValidStructure();
+          });
         });
       });
 
-      describe('when value is not present', () => {
-        it('is valid', () => {
-          const user = new CircularUser({
-            favoriteBook: {},
+      describe('required', () => {
+        describe('when value is present', () => {
+          it('is valid', () => {
+            const user = new CircularUser({
+              favoriteBook: {},
+            });
+
+            expect(user).toBeValidStructure();
           });
-
-          expect(user).toBeValidStructure();
         });
-      });
-    });
 
-    describe('required', () => {
-      describe('when value is present', () => {
-        it('is valid', () => {
-          const user = new CircularUser({
-            favoriteBook: {},
+        describe('when value is not present', () => {
+          it('is invalid', () => {
+            const user = new CircularUser();
+
+            expect(user).toHaveInvalidAttribute(['favoriteBook'], ['"favoriteBook" is required']);
           });
-
-          expect(user).toBeValidStructure();
-        });
-      });
-
-      describe('when value is not present', () => {
-        it('is invalid', () => {
-          const user = new CircularUser();
-
-          expect(user).toHaveInvalidAttribute(['favoriteBook'], ['"favoriteBook" is required']);
-        });
-      });
-    });
-
-    describe('nested required', () => {
-      describe('when value is present', () => {
-        it('is valid', () => {
-          const book = new CircularBook({
-            owner: {
-              favoriteBook: new CircularBook(),
-            },
-          });
-
-          expect(book).toBeValidStructure();
         });
       });
 
-      describe('when value is not present', () => {
-        it('is invalid', () => {
-          const book = new CircularBook({
-            owner: new CircularUser(),
-          });
+      describe('nested required', () => {
+        describe('when value is present', () => {
+          it('is valid', () => {
+            const book = new CircularBook({
+              owner: {
+                favoriteBook: new CircularBook(),
+              },
+            });
 
-          expect(book).toHaveInvalidAttribute(
-            ['owner', 'favoriteBook'],
-            ['"owner.favoriteBook" is required']
-          );
+            expect(book).toBeValidStructure();
+          });
+        });
+
+        describe('when value is not present', () => {
+          it('is invalid', () => {
+            const book = new CircularBook({
+              owner: new CircularUser(),
+            });
+
+            expect(book).toHaveInvalidAttribute(
+              ['owner', 'favoriteBook'],
+              ['"owner.favoriteBook" is required']
+            );
+          });
         });
       });
     });


### PR DESCRIPTION
Since Joi was updated we're now required to have a well-defined identifier for each structure in order to use validation of dynamic-type attributes. Until now the class name was being used for that but it's not a reliable source for every environment.  For this reason, it's not possible to set a custom identifier for a structure.