### PR TITLE
Allow to declare custom setter and getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Refactors:
 Enhancements
 
 - Implement jest-structure assertions
+- It's possible to set custom getters e setters directly in the structure class
 
 Breaking changes:
 
@@ -18,6 +19,7 @@ Breaking changes:
   - Attribute path in validation _messages_ contains the whole path joined by '.'
   - The name used for the dynamic import should aways be the same as the name of its type or else a custom identifier must be used
 - Non-nullable attributes with value null will use default value the same way undefined does
+- Structure classes now have two methods to generically set and get the value of the attributes, `.get(attributeName)` and `.set(attributeName, attributeValue)`
 
 ## 1.8.0 - 2019-09-16
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
   - [Shorthand and complete type descriptor](schema-concept/shorthand-and-complete-type-descriptor.md)
   - [Circular reference](schema-concept/circular-references-and-dynamic-types.md)
   - [Nullable attributes](schema-concept/nullable-attributes.md)
+- [Custom setters and getters](custom-setters-and-getters.md)
 - [Coercion](coercion/README.md)
   - [Primitive type coercion](coercion/primitive-type-coercion.md)
   - [Arrays coercion](coercion/arrays-and-array-subclasses.md)

--- a/docs/custom-setters-and-getters.md
+++ b/docs/custom-setters-and-getters.md
@@ -1,0 +1,39 @@
+# Custom setters and getters
+
+Sometimes it may be necessary to have custom setters and/or getters for some attributes. Structure allows you to do that using native JavaScript setters and getters. It will even support coercion.
+
+It's important to notice that you **should not** try to access the attribute directly inside its getter or to set it directly inside its setter because it will cause infinite recursion, this is default JavaScript behavior. To access an attribute value inside its getter you should use `this.get(attributeName)`, and to set the value of an attribute a setter you should use `this.set(attributeName, attributeValue)`:
+
+```js
+const User = attributes({
+  firstName: String,
+  lastName: String,
+  age: Number,
+})(
+  class User {
+    get firstName() {
+      return `-> ${this.get('firstName')}`;
+    }
+
+    set lastName(newLastname) {
+      return this.set('lastName', `Mac${newLastName}`);
+    }
+
+    get age() {
+      // do NOT do that. Instead, use this.get and this.set inside getters and setters
+      return this.age * 1000;
+    }
+
+    // this is NOT an attribute, just a normal getter
+    get fullName() {
+      return `${this.firstName} ${this.lastName}`;
+    }
+  }
+);
+
+const user = new User({ firstName: 'Connor', lastName: 'Leod' });
+
+user.firstName; // -> Connor
+user.lastName; // MacLeod
+user.fullName; // -> Connor MacLeod
+```

--- a/docs/custom-setters-and-getters.md
+++ b/docs/custom-setters-and-getters.md
@@ -37,3 +37,50 @@ user.firstName; // -> Connor
 user.lastName; // MacLeod
 user.fullName; // -> Connor MacLeod
 ```
+
+## Inheritance
+
+Custom setters and getters are also inherited, be your superclass a pure JavaScript class or another structure:
+
+```js
+class Person {
+  // If Person was a structure instead of a pure class, that would work too
+  get name() {
+    return 'The person';
+  }
+}
+
+const User = attributes({
+  name: String,
+})(class User extends Person {});
+
+const user = new User({ name: 'Will not be used' });
+
+user.name; // -> The person
+```
+
+**Important**
+
+JavaScript nativelly won't let you inherit only one of the accessors (the getter or the setter) if you define the other accessor in a subclass:
+
+```js
+class Person {
+  get name() {
+    return 'Person';
+  }
+}
+
+class User extends Person {
+  set name(newName) {
+    this._name = newName;
+  }
+}
+
+const user = new Person();
+user.name = 'The user';
+user.name; // -> The user
+```
+
+It happens because _once you define one of the accessors in a subclass_, all the accessors for the same attribute inherited from the superclass will be ignored.
+
+While it's a weird behavior, Structure will follow the same functionality so the Structure classes inheritance work the same way of pure JavaScript classes, avoiding inconsistencies.

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -37,7 +37,7 @@
     "build": "webpack",
     "prepublish": "yarn run build",
     "coveralls": "yarn run coverage --coverageReporters=text-lcov | coveralls",
-    "lint": "eslint {src,test,benchmark}/**/*.js",
+    "lint": "eslint {src,test}/**/*.js",
     "format": "prettier --write {src,test}/**/*.js"
   },
   "dependencies": {

--- a/packages/structure/src/attributes/index.js
+++ b/packages/structure/src/attributes/index.js
@@ -1,0 +1,8 @@
+const { ATTRIBUTES } = require('../symbols');
+
+exports.setInInstance = function setAttributesInInstance(instance, attributes) {
+  Object.defineProperty(instance, ATTRIBUTES, {
+    configurable: true,
+    value: attributes,
+  });
+};

--- a/packages/structure/src/errors/index.js
+++ b/packages/structure/src/errors/index.js
@@ -18,3 +18,6 @@ exports.invalidType = (attributeName) =>
 
 exports.invalidAttributes = (errors, StructureValidationError) =>
   new StructureValidationError(errors);
+
+exports.inexistentAttribute = (attributeName) =>
+  new Error(`${attributeName} is not an attribute of this structure`);

--- a/packages/structure/src/initialization/index.js
+++ b/packages/structure/src/initialization/index.js
@@ -1,15 +1,11 @@
-const { ATTRIBUTES } = require('../symbols');
+const Attributes = require('../attributes');
 
 exports.for = function initializationForSchema(schema) {
   return {
     initialize(instance, { attributes }) {
-      Object.defineProperty(instance, ATTRIBUTES, {
-        configurable: true,
-        value: Object.create(null),
-      });
+      Attributes.setInInstance(instance, Object.create(null));
 
-      for (let i = 0; i < schema.attributeDefinitions.length; i++) {
-        const attrDefinition = schema.attributeDefinitions[i];
+      for (let attrDefinition of schema.attributeDefinitions) {
         const attrPassedValue = attributes[attrDefinition.name];
 
         // will coerce through setters

--- a/packages/structure/src/schema/index.js
+++ b/packages/structure/src/schema/index.js
@@ -83,6 +83,18 @@ class Schema {
 
     return this.validation.validate(attributes);
   }
+
+  coerce(newAttributes) {
+    const attributes = Object.create(null);
+
+    for (const attributeDefinition of this.attributeDefinitions) {
+      const { name } = attributeDefinition;
+      const value = newAttributes[name];
+      attributes[name] = attributeDefinition.coerce(value);
+    }
+
+    return attributes;
+  }
 }
 
 module.exports = Schema;

--- a/packages/structure/src/symbols.js
+++ b/packages/structure/src/symbols.js
@@ -1,4 +1,5 @@
 module.exports = {
   SCHEMA: Symbol('schema'),
   ATTRIBUTES: Symbol('attributes'),
+  DEFAULT_ACCESSOR: Symbol('defaultAccessor'),
 };

--- a/packages/structure/test/unit/__snapshots__/instanceAndUpdate.spec.js.snap
+++ b/packages/structure/test/unit/__snapshots__/instanceAndUpdate.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`instantiating a structure custom setters and getters when tries to set an attribute that does not exist fails and throws an error 1`] = `"NOPE is not an attribute of this structure"`;

--- a/packages/structure/test/unit/subclassingStructureClass.spec.js
+++ b/packages/structure/test/unit/subclassingStructureClass.spec.js
@@ -169,7 +169,14 @@ describe('subclassing a structure with another structure', () => {
         type: String,
         default: () => 123,
       },
-    })(class User {});
+      age: Number,
+    })(
+      class User {
+        set age(newAge) {
+          this.set('age', Math.abs(newAge));
+        }
+      }
+    );
 
     Admin = attributes({
       level: Number,
@@ -218,22 +225,36 @@ describe('subclassing a structure with another structure', () => {
       });
     });
   });
+
+  describe('custom accessor in parent class', () => {
+    it("won't override the custom accessor from the superclass with the default one from the subclass", () => {
+      const admin = new Admin({ age: -1 });
+
+      expect(admin.age).toEqual(1);
+    });
+  });
 });
 
 describe('subclassing a POJO class with a structure', () => {
   let Employee;
   let Writer;
   let Reviewer;
+  let SuperEmployee;
 
   beforeEach(() => {
     Employee = class Employee {
       getType() {
         return this.type.toUpperCase();
       }
+
+      get company() {
+        return 'ACME';
+      }
     };
 
     Writer = attributes({ type: String })(class Writer extends Employee {});
     Reviewer = attributes({ type: String })(class Reviewer extends Employee {});
+    SuperEmployee = attributes({ company: String })(class SuperEmployee extends Employee {});
   });
 
   describe('when structure attribute is a structure which extends a POJO', () => {
@@ -285,6 +306,14 @@ describe('subclassing a POJO class with a structure', () => {
 
       expect(company.employees[1]).toBeInstanceOf(Reviewer);
       expect(company.employees[1].getType()).toBe('REVIEWER');
+    });
+  });
+
+  describe('custom accessor in parent class', () => {
+    it("won't override the custom accessor from the superclass with the default one from the subclass", () => {
+      const superEmployee = new SuperEmployee({ company: 'Monster Inc.' });
+
+      expect(superEmployee.company).toEqual('ACME');
     });
   });
 });


### PR DESCRIPTION
This PR adds the possibility to use custom getters and setters for attributes. These setters and getters can be inherited from both POJO and structure subclasses.

---

- [x] Without inheritance
- [x] Generic `set`/`get`methods to be used inside custom setters and getters
- [x] Inherit custom setters