### PR TITLE
Add joi validation type to error details

### DIFF
--- a/packages/structure/src/validation/forSchema.js
+++ b/packages/structure/src/validation/forSchema.js
@@ -45,4 +45,4 @@ module.exports = function validationForSchema(schema) {
   };
 };
 
-const mapDetail = ({ message, path }) => ({ message, path });
+const mapDetail = ({ message, path, type }) => ({ message, path, type });

--- a/packages/structure/test/unit/instanceAndUpdate.spec.js
+++ b/packages/structure/test/unit/instanceAndUpdate.spec.js
@@ -234,6 +234,7 @@ describe('instantiating a structure', () => {
               {
                 message: '"password" is required',
                 path: ['password'],
+                type: 'any.required',
               },
             ];
 
@@ -388,6 +389,7 @@ describe('instantiating a structure with dynamic attribute types', () => {
           {
             message: '"favoriteBook.pages" must be a number',
             path: ['favoriteBook', 'pages'],
+            type: 'number.base',
           },
         ];
 
@@ -678,6 +680,7 @@ describe('cloning an instance', () => {
             {
               message: '"name" is required',
               path: ['name'],
+              type: 'any.required',
             },
           ];
 
@@ -704,6 +707,7 @@ describe('cloning an instance', () => {
               {
                 message: '"favoriteBook.name" is required',
                 path: ['favoriteBook', 'name'],
+                type: 'any.required',
               },
             ];
 

--- a/packages/structure/test/unit/validation/staticMethod.spec.js
+++ b/packages/structure/test/unit/validation/staticMethod.spec.js
@@ -50,7 +50,9 @@ describe('validation', () => {
         expect(errors).toBeInstanceOf(Array);
         expect(errors).toHaveLength(2);
         expect(errors[0].path).toEqual(['name']);
+        expect(errors[0].type).toEqual('any.required');
         expect(errors[1].path).toEqual(['age']);
+        expect(errors[1].type).toEqual('number.min');
       });
     });
 
@@ -72,6 +74,7 @@ describe('validation', () => {
           expect(errors).toBeInstanceOf(Array);
           expect(errors).toHaveLength(1);
           expect(errors[0].path).toEqual(['name']);
+          expect(errors[0].type).toEqual('string.base');
         });
       });
     });
@@ -104,6 +107,7 @@ describe('validation', () => {
           expect(errors).toBeInstanceOf(Array);
           expect(errors).toHaveLength(1);
           expect(errors[0].path).toEqual(['favoriteBook', 'name']);
+          expect(errors[0].type).toEqual('any.required');
         });
       });
 
@@ -136,6 +140,7 @@ describe('validation', () => {
           expect(errors).toBeInstanceOf(Array);
           expect(errors).toHaveLength(1);
           expect(errors[0].path).toEqual(['user', 'name']);
+          expect(errors[0].type).toEqual('string.base');
         });
       });
     });
@@ -167,7 +172,9 @@ describe('validation', () => {
           expect(errors).toBeInstanceOf(Array);
           expect(errors).toHaveLength(2);
           expect(errors[0].path).toEqual(['name']);
+          expect(errors[0].type).toEqual('any.required');
           expect(errors[1].path).toEqual(['age']);
+          expect(errors[1].type).toEqual('number.min');
         });
       });
 
@@ -204,6 +211,7 @@ describe('validation', () => {
           expect(errors).toBeInstanceOf(Array);
           expect(errors).toHaveLength(1);
           expect(errors[0].path).toEqual(['user', 'name']);
+          expect(errors[0].type).toEqual('any.required');
         });
       });
     });


### PR DESCRIPTION
The aim of this PR is to include the `type` parameter from the joi error detail, which will be handy while localizing the error messages.